### PR TITLE
Fixes null Post when using image in repeater

### DIFF
--- a/src/Field/Image.php
+++ b/src/Field/Image.php
@@ -60,7 +60,8 @@ class Image extends BasicField implements FieldInterface
     {
         $attachmentId = $this->fetchValue($field);
 
-        $attachment = $this->post->find(intval($attachmentId));
+        $attachment = $this->post->attachment()->find(intval($attachmentId));
+        
         $this->fillFields($attachment);
 
         $imageData = $this->fetchMetadataValue($attachment);


### PR DESCRIPTION
For some reason `$this->post->find(intval($attachmentId));` was returning `null` even though the image did exists.