### PR TITLE
Fix to Image Field still returning null

### DIFF
--- a/src/Field/Image.php
+++ b/src/Field/Image.php
@@ -62,13 +62,13 @@ class Image extends BasicField implements FieldInterface
            
         $connection = $this->post->getConnectionName();
         
-        $attachment = Post::on($connection)->find(intval($attachmentId));
-        
-        $this->fillFields($attachment);
+        if ($attachment = Post::on($connection)->find(intval($attachmentId))) {
+            $this->fillFields($attachment);
 
-        $imageData = $this->fetchMetadataValue($attachment);
+            $imageData = $this->fetchMetadataValue($attachment);
         
-        $this->fillMetadataFields($imageData);
+            $this->fillMetadataFields($imageData);
+        }
     }
 
     /**

--- a/src/Field/Image.php
+++ b/src/Field/Image.php
@@ -59,8 +59,10 @@ class Image extends BasicField implements FieldInterface
     public function process($field)
     {
         $attachmentId = $this->fetchValue($field);
-
-        $attachment = Post::find(intval($attachmentId));
+           
+        $connection = $this->post->getConnectionName();
+        
+        $attachment = Post::on($connection)->find(intval($attachmentId));
         
         $this->fillFields($attachment);
 

--- a/src/Field/Image.php
+++ b/src/Field/Image.php
@@ -2,8 +2,8 @@
 
 namespace Corcel\Acf\Field;
 
-use Corcel\Acf\FieldInterface;
 use Corcel\Post;
+use Corcel\Acf\FieldInterface;
 use Illuminate\Database\Eloquent\Collection;
 
 /**
@@ -60,11 +60,12 @@ class Image extends BasicField implements FieldInterface
     {
         $attachmentId = $this->fetchValue($field);
 
-        $attachment = $this->post->attachment()->find(intval($attachmentId));
+        $attachment = Post::find(intval($attachmentId));
         
         $this->fillFields($attachment);
 
         $imageData = $this->fetchMetadataValue($attachment);
+        
         $this->fillMetadataFields($imageData);
     }
 


### PR DESCRIPTION
@jgrossi I was playing around with this some more and re-discovered what the actual issue use. Using `$this->attachment()` actually only works if you uploaded the image to the post, but if you want to re-use an image on a different post `null` would still be returned.
