### PR TITLE
Add support for Clone Field

### DIFF
--- a/src/Field/BasicField.php
+++ b/src/Field/BasicField.php
@@ -115,7 +115,7 @@ abstract class BasicField
      */
     public function fetchFieldType($fieldKey)
     {
-        // Check if this a clone field. If it is, return the field type of it's clone.
+        // Check if this a clone field. If it is, return the field type of its clone.
         $fieldKeyIds = explode('_', $fieldKey);
         if (count($fieldKeyIds) == 4) {
             $fieldKey = 'field_' . $fieldKeyIds[3];

--- a/src/Field/BasicField.php
+++ b/src/Field/BasicField.php
@@ -115,6 +115,12 @@ abstract class BasicField
      */
     public function fetchFieldType($fieldKey)
     {
+        // Check if this a clone field. If it is, return the field type of it's clone.
+        $fieldKeyIds = explode('_', $fieldKey);
+        if (count($fieldKeyIds) == 4) {
+            $fieldKey = 'field_' . $fieldKeyIds[3];
+        }
+
         $post = $this->post->orWhere(function ($query) use ($fieldKey) {
             $query->where('post_name', $fieldKey);
             $query->where('post_type', 'acf-field');


### PR DESCRIPTION
If you use the clone field type (fairly new acf type that clones another field) then you get an error:
Call to a member function get() on null
ACF stores clone fields as {fieldkey}_{clonedfieldkey} e.g `field_58d217c0bbeef_field_58cb8919c2607`

so we can extract the parent's field type instead and everything works as expected.
