### PR TITLE
Fix for getFieldType sometimes returning the wrong post

### DIFF
--- a/src/Field/BasicField.php
+++ b/src/Field/BasicField.php
@@ -115,7 +115,7 @@ abstract class BasicField
      */
     public function fetchFieldType($fieldKey)
     {
-        $post = $this->post->orWhere(function ($query) use ($fieldKey) {
+        $post = Post::where(function ($query) use ($fieldKey) {
             $query->where('post_name', $fieldKey);
             $query->where('post_type', 'acf-field');
         })->first();


### PR DESCRIPTION
Fix for getFieldType sometimes returning the wrong post, e.g not an ACF field.

I was debugging for a while, trying to work out why my Repeater Fields were coming back as Text.
It seemed that the query in fetchFieldType was returning the wrong post.
I am not sure why it was built to use `->orWhere()` as it seems like you are not guaranteed to get the post with post_name = $fieldKey and post_type = 'acf-field'. Shouldn't this query explicitly look for one row matching those parameters?

In my case, it resolved the issue I was experiencing.