### PR TITLE
Fixes regarding handling of image sizes, in the Image class.

### DIFF
--- a/src/Field/Image.php
+++ b/src/Field/Image.php
@@ -92,16 +92,17 @@ class Image extends BasicField implements FieldInterface
 
     /**
      * @param string $size
+     * @param bool $useOriginalFallback
      *
      * @return Image
      */
-    public function size($size)
+    public function size($size, $useOriginalFallback = false)
     {
         if (isset($this->sizes[$size])) {
             return $this->fillThumbnailFields($this->sizes[$size]);
         }
 
-        return $this->fillThumbnailFields($this->sizes['thumbnail']);
+        return $useOriginalFallback ? $this : $this->fillThumbnailFields($this->sizes['thumbnail']);
     }
 
     /**

--- a/src/Field/Image.php
+++ b/src/Field/Image.php
@@ -118,6 +118,9 @@ class Image extends BasicField implements FieldInterface
         $size->height = $data['height'];
         $size->mime_type = $data['mime-type'];
 
+        $urlPath = dirname($this->url);
+        $size->url = sprintf('%s/%s', $urlPath, $size->filename);
+
         return $size;
     }
 

--- a/tests/ContentFieldsTest.php
+++ b/tests/ContentFieldsTest.php
@@ -53,7 +53,20 @@ class ContentFieldsTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('1920', $image->width);
         $this->assertEquals('1080', $image->height);
         $this->assertEquals('maxresdefault-1.jpg', $image->filename);
+
+        // Test existing image size
         $this->assertEquals('1024', $image->size('large')->width);
+        $this->assertNotEmpty($image->size('large')->url);
+
+        // Test non existing image size with thumbnail as fallback
+        $this->assertEquals('150', $image->size('fake_size')->width);
+        $this->assertNotEmpty($image->size('fake_size')->url);
+
+        // Test non existing image size with original as fallback
+        $this->assertEquals($image->width, $image->size('fake_size', true)->width);
+        $this->assertEquals($image->height, $image->size('fake_size', true)->height);
+        $this->assertNotEmpty($image->size('fake_size', true)->url);
+
         $this->assertEquals('image/jpeg', $image->mime_type);
         $this->assertEquals('This is a caption', $image->description);
     }


### PR DESCRIPTION
Two issues addressed, regarding the Image field class.

1. URL field was not being filled in the `fillThumbnailFields` method. (So, calls like this: `$image->size('large')->url` would be `null`
2. Added the option to have the original image as a fallback, when requesting a certain thumbnail size, if said size does not exist, or the crop for this size has not been created. This resembles the default WordPress behavior.
3. Added new assertions to test the above items.

Unit test results:

```
PHPUnit 4.2.2 by Sebastian Bergmann.

Configuration read from [...]\acf\phpunit.xml

................................................

Time: 640 ms, Memory: 13.00MB

OK (48 tests, 105 assertions)
```