### PR TITLE
Make it possible to define custom acf types

### DIFF
--- a/src/FieldFactory.php
+++ b/src/FieldFactory.php
@@ -49,65 +49,53 @@ class FieldFactory
             $type = $fakeText->fetchFieldType($key);
         }
 
+        $default_types = [
+            'text'             => Text::class,
+            'textarea'         => Text::class,
+            'number'           => Text::class,
+            'email'            => Text::class,
+            'url'              => Text::class,
+            'password'         => Text::class,
+            'wysiwyg'          => Text::class,
+            'editor'           => Text::class,
+            'oembed'           => Text::class,
+            'embed'            => Text::class,
+            'color_picker'     => Text::class,
+            'select'           => Text::class,
+            'checkbox'         => Text::class,
+            'radio'            => Text::class,
+            'image'            => Image::class,
+            'img'              => Image::class,
+            'file'             => File::class,
+            'gallery'          => Gallery::class,
+            'true_false'       => Boolean::class,
+            'boolean'          => Boolean::class,
+            'post_object'      => PostObject::class,
+            'post'             => PostObject::class,
+            'relationship'     => PostObject::class,
+            'page_link'        => PageLink::class,
+            'taxonomy'         => Term::class,
+            'term'             => Term::class,
+            'user'             => User::class,
+            'date_picker'      => DateTime::class,
+            'date_time_picker' => DateTime::class,
+            'time_picker'      => DateTime::class,
+            'repeater'         => Repeater::class,
+            'flexible_content' => FlexibleContent::class,
+        ];
 
-        switch ($type) {
-            case 'text':
-            case 'textarea':
-            case 'number':
-            case 'email':
-            case 'url':
-            case 'password':
-            case 'wysiwyg':
-            case 'editor':
-            case 'oembed':
-            case 'embed':
-            case 'color_picker':
-            case 'select':
-            case 'checkbox':
-            case 'radio':
-                $field = new Text($post);
-                break;
-            case 'image':
-            case 'img':
-                $field = new Image($post);
-                break;
-            case 'file':
-                $field = new File($post);
-                break;
-            case 'gallery':
-                $field = new Gallery($post);
-                break;
-            case 'true_false':
-            case 'boolean':
-                $field = new Boolean($post);
-                break;
-            case 'post_object':
-            case 'post':
-            case 'relationship':
-                $field = new PostObject($post);
-                break;
-            case 'page_link':
-                $field = new PageLink($post);
-                break;
-            case 'taxonomy':
-            case 'term':
-                $field = new Term($post);
-                break;
-            case 'user':
-                $field = new User($post);
-                break;
-            case 'date_picker':
-            case 'date_time_picker':
-            case 'time_picker':
-                $field = new DateTime($post);
-                break;
-            case 'repeater':
-                $field = new Repeater($post);
-                break;
-            case 'flexible_content':
-                $field = new FlexibleContent($post);
-                break;
-            default: return null;
+        $custom_types = [];
+
+        if (\Config::has('corcel.acf.custom_types')) {
+            $custom_types = \Config::get('corcel.acf.custom_types');
+        }
+
+        $types = array_merge($default_types, $custom_types);
+
+        if (!empty($types[$type])) {
+            $field = new $types[$type]($post);
+        } else {
+            return null;
         }
 
         $field->process($name);


### PR DESCRIPTION
Example: corcel.config.php

`
<?php

use Corcel\Acf\Field\Text;

return [
    'acf' => [
        'forms' => Text::class,
    ]
];
`