### PR TITLE
Added a hardcast to (int) on a field used in a range

### DIFF
--- a/src/Field/Repeater.php
+++ b/src/Field/Repeater.php
@@ -74,7 +74,7 @@ class Repeater extends BasicField implements FieldInterface
      */
     protected function fetchPostsMeta($fieldName, Post $post)
     {
-        $count = $this->fetchValue($fieldName, $post);
+        $count = (int) $this->fetchValue($fieldName, $post);
         $builder = $this->postMeta->where('post_id', $post->ID);
         $builder->where(function ($query) use ($count, $fieldName) {
             foreach (range(0, $count - 1) as $i) {


### PR DESCRIPTION
My local Wordpress installation sometimes returns a string representation of the integer, or something completely invalid.  That triggers a problem om line 80, where an int must be supplied. 

I can't reliably reproduce the problem, as it is probably related to database corruption when changing already filled ACF fieldsets. But at the very least this change generates a more meaningful error message. 