### PR TITLE
Missing null checks

### DIFF
--- a/src/Field/FlexibleContent.php
+++ b/src/Field/FlexibleContent.php
@@ -99,7 +99,7 @@ class FlexibleContent extends BasicField implements FieldInterface
             $post = $this->post->ID != $meta->post_id ? $this->post->find($meta->post_id) : $this->post;
             $field = FieldFactory::make($meta->meta_key, $post);
 
-            if (!array_key_exists($id, $blocks)) {
+            if ($field === null || !array_key_exists($id, $blocks)) {
                 continue;
             }
 


### PR DESCRIPTION
I've ran into a couple of variables that could be null, leading to fatal crashes when the wordpress database is polluted. It's better to ignore these invalid entries silently instead of failing the entire page. 