### PR TITLE
Image must expose its attachment

### DIFF
--- a/src/Field/Image.php
+++ b/src/Field/Image.php
@@ -85,6 +85,8 @@ class Image extends BasicField implements FieldInterface
      */
     protected function fillFields(Post $attachment)
     {
+        $this->attachment = $attachment;
+
         $this->mime_type = $attachment->post_mime_type;
         $this->url = $attachment->guid;
         $this->description = $attachment->post_excerpt;


### PR DESCRIPTION
In the current state, it is not possible to retrieve the alt-text of an Image Field. Exposing the attachment on the Image class results in a similar API to ThumbnailMeta, so one can retrieve image-meta-data through 

```php
$image->attachment->meta->_wp_attachment_image_alt;
```