### PR TITLE
Sort Post Object if multiple by defined position in Wordpress

### DIFF
--- a/src/Field/PostObject.php
+++ b/src/Field/PostObject.php
@@ -26,7 +26,9 @@ class PostObject extends BasicField implements FieldInterface
         $connection = $this->post->getConnectionName();
         
         if (is_array($postId)) {
-            $this->object = Post::on($connection)->whereIn('ID', $postId)->get();
+            $this->object = Post::on($connection)->whereIn('ID', $postId)->get()->sortBy(function ($item) use ($postId) {
+                return array_search($item->getKey(), $postId);
+            });
         } else {
             $this->object = Post::on($connection)->find($postId);
         }


### PR DESCRIPTION
In Wordpress admin you can sort posts manually in the UI, this order will not return by Corcel/ACF.

So I added the collection SortBy method to sort the results by the given array with id's.