### PR TITLE
Typed ACF Relationships

### DIFF
--- a/src/Field/PostObject.php
+++ b/src/Field/PostObject.php
@@ -46,6 +46,11 @@ class PostObject extends BasicField implements FieldInterface
         return $this->object;
     }
 
+    /**
+     * Downcast a model to its appropriate subclass
+     * @param  Corcel\Post   $post
+     * @return Corcel\Post   an appropriate (sub)class
+     */
     private function downcast(Post $post)
     {
         $class = Post::$postTypes[$post->post_type] ?? Post::class;


### PR DESCRIPTION
It would be very useful if ACF relationships returned the model as set in Corcel\Post::$postTypes. I wrote a very implementation that does that in this PR. Not ready for merge though, I have two remaining corncerns:

1.  This runs an additional query for every post that should be downcasted. Is there a way we could get around this? 
1. This requires Corcel\Post::$postTypes to be made public. 