### PR TITLE
Let File has attachment property like Image has

### DIFF
--- a/src/Field/File.php
+++ b/src/Field/File.php
@@ -43,6 +43,11 @@ class File extends BasicField implements FieldInterface
     public $mime_type;
 
     /**
+     * @var Post
+     */
+    public $attachment;
+
+    /**
      * @param string $field
      */
     public function process($field)
@@ -75,5 +80,6 @@ class File extends BasicField implements FieldInterface
         $this->description = $file->post_content;
         $this->caption = $file->post_excerpt;
         $this->filename = basename($this->url);
+        $this->attachment = $file;
     }
 }


### PR DESCRIPTION
The File object does not have an attachment property, where the Image object does. I added this property to the File object.

In my case my uploads are stored in S3, so I need the meta of the file to get the S3 url.