### PR TITLE
Fix gallery field when appended to a term

### DIFF
--- a/src/Field/Image.php
+++ b/src/Field/Image.php
@@ -150,10 +150,10 @@ class Image extends BasicField implements FieldInterface
         $ids = $attachments->pluck('ID')->toArray();
         $metadataValues = [];
 
-        $metaRows = $this->postMeta->whereIn('post_id', $ids)
+        $metaRows = PostMeta::whereIn("post_id", $ids)
             ->where('meta_key', '_wp_attachment_metadata')
             ->get();
-
+            
         foreach ($metaRows as $meta) {
             $metadataValues[$meta->post_id] = unserialize($meta->meta_value);
         }


### PR DESCRIPTION
When you append a Gallery field to a taxonomy term, the metadata of the images will be fetched with $this->postmeta, but that method gives an instance of TermMeta because thats the postmeta relation of the related term.

I replaced $this->postmeta by a fresh PostMeta static class, because an image is always a Post.