### PR TITLE
fixed a missing null check in Repeater.php

### DIFF
--- a/src/Field/Repeater.php
+++ b/src/Field/Repeater.php
@@ -103,9 +103,13 @@ class Repeater extends BasicField implements FieldInterface
         foreach ($builder->get() as $meta) {
             $id = $this->retrieveIdFromFieldName($meta->meta_key, $fieldName);
             $name = $this->retrieveFieldName($meta->meta_key, $fieldName, $id);
-            
+
             $post = $this->post->ID != $meta->post_id ? $this->post->find($meta->post_id) : $this->post;
             $field = FieldFactory::make($meta->meta_key, $post);
+
+            if ($field == null) {
+                continue;
+            }
 
             $fields[$id][$name] = $field->get();
         }


### PR DESCRIPTION
Encountered a null pointer bug in production last month. I think the reproduction path is:

1. Create a repeater, add two fields to it
1. Add some content to a post in those fields
1. Delete one of the fields. 

Corcel than returns null from the FieldFactory, but still tries to use the field. 

Added a null check to prevent it.