### PR TITLE
Replace Corcel 1.x model with the 2.* notation

### DIFF
--- a/src/Field/Repeater.php
+++ b/src/Field/Repeater.php
@@ -76,7 +76,7 @@ class Repeater extends BasicField implements FieldInterface
     {
         $count = (int) $this->fetchValue($fieldName);
         
-        if ($this->postMeta instanceof \Corcel\TermMeta) {
+        if ($this->postMeta instanceof \Corcel\Model\Meta\TermMeta) {
             $builder = $this->postMeta->where('term_id', $post->term_id);
         } else {
             $builder = $this->postMeta->where('post_id', $post->ID);


### PR DESCRIPTION
Fix an issue for the repeater component for getting the meta data of the base object when that base object is a taxonomy. 

The instanceof check was performing on a Corcel model in the 1.x style. I replaced that with the namespace of the 2.x version.