### PR TITLE
Support for option page, refactored & fixed unittests, fixed flexible content field

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     }
   ],
   "require": {
-    "php": ">=5.5.9",
-    "jgrossi/corcel": "~2.4"
+    "php": ">=7.0.0",
+    "jgrossi/corcel": "~2.5"
   },
   "require-dev": {
     "phpunit/phpunit": "~6.0",

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,17 @@
   ],
   "require": {
     "php": ">=5.5.9",
-    "jgrossi/corcel": "~2.1"
+    "jgrossi/corcel": "~2.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.8"
+    "phpunit/phpunit": "~6.0",
+    "orchestra/testbench": "~3.4",
+    "orchestra/database": "~3.4"
   },
   "autoload": {
     "psr-4": {
-      "Corcel\\Acf\\": "src/"
+      "Corcel\\Acf\\": "src/",
+      "Corcel\\Acf\\Tests\\": "tests/"
     }
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,37 +4,38 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d63d5065b4c1ebd16337c68bc0cd839",
+    "hash": "242a7fcc0edad52371caf6d44d5ec72b",
+    "content-hash": "3f58b9879134d84c78bbe8a27ab8fe4f",
     "packages": [
         {
             "name": "doctrine/inflector",
-            "version": "v1.1.0",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae"
+                "reference": "e11d84c6e018beedd929cff5220969a3c6d1d462"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/90b2128806bfde671b6952ab8bea493942c1fdae",
-                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/e11d84c6e018beedd929cff5220969a3c6d1d462",
+                "reference": "e11d84c6e018beedd929cff5220969a3c6d1d462",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.*"
+                "phpunit/phpunit": "^6.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Common\\Inflector\\": "lib/"
+                "psr-4": {
+                    "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -71,33 +72,80 @@
                 "singularize",
                 "string"
             ],
-            "time": "2015-11-06T14:35:42+00:00"
+            "time": "2017-07-22 12:18:28"
         },
         {
-            "name": "fzaninotto/faker",
-            "version": "v1.6.0",
+            "name": "erusev/parsedown",
+            "version": "1.6.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123"
+                "url": "https://github.com/erusev/parsedown.git",
+                "reference": "fbe3fe878f4fe69048bb8a52783a09802004f548"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/44f9a286a04b80c76a4e5fb7aad8bb539b920123",
-                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123",
+                "url": "https://api.github.com/repos/erusev/parsedown/zipball/fbe3fe878f4fe69048bb8a52783a09802004f548",
+                "reference": "fbe3fe878f4fe69048bb8a52783a09802004f548",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3|^7.0"
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Parsedown": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Emanuil Rusev",
+                    "email": "hello@erusev.com",
+                    "homepage": "http://erusev.com"
+                }
+            ],
+            "description": "Parser for Markdown.",
+            "homepage": "http://parsedown.org",
+            "keywords": [
+                "markdown",
+                "parser"
+            ],
+            "time": "2017-11-14 20:44:03"
+        },
+        {
+            "name": "fzaninotto/faker",
+            "version": "v1.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fzaninotto/Faker.git",
+                "reference": "d3ed4cc37051c1ca52d22d76b437d14809fc7e0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/d3ed4cc37051c1ca52d22d76b437d14809fc7e0d",
+                "reference": "d3ed4cc37051c1ca52d22d76b437d14809fc7e0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
                 "ext-intl": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~1.5"
+                "phpunit/phpunit": "^4.0 || ^5.0",
+                "squizlabs/php_codesniffer": "^1.5"
             },
             "type": "library",
             "extra": {
-                "branch-alias": []
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
             },
             "autoload": {
                 "psr-4": {
@@ -119,7 +167,7 @@
                 "faker",
                 "fixtures"
             ],
-            "time": "2016-04-29T12:21:54+00:00"
+            "time": "2017-08-15 16:48:10"
         },
         {
             "name": "hautelook/phpass",
@@ -163,291 +211,37 @@
                 "password",
                 "security"
             ],
-            "time": "2012-08-31T00:00:00+00:00"
-        },
-        {
-            "name": "illuminate/container",
-            "version": "v5.2.45",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/illuminate/container.git",
-                "reference": "5139cebc8293b6820b91aef6f4b4e18bde33c9b2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/container/zipball/5139cebc8293b6820b91aef6f4b4e18bde33c9b2",
-                "reference": "5139cebc8293b6820b91aef6f4b4e18bde33c9b2",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/contracts": "5.2.*",
-                "php": ">=5.5.9"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Illuminate\\Container\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Taylor Otwell",
-                    "email": "taylor@laravel.com"
-                }
-            ],
-            "description": "The Illuminate Container package.",
-            "homepage": "http://laravel.com",
-            "time": "2016-08-01T13:49:14+00:00"
-        },
-        {
-            "name": "illuminate/contracts",
-            "version": "v5.2.45",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/illuminate/contracts.git",
-                "reference": "22bde7b048a33c702d9737fc1446234fff9b1363"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/contracts/zipball/22bde7b048a33c702d9737fc1446234fff9b1363",
-                "reference": "22bde7b048a33c702d9737fc1446234fff9b1363",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Illuminate\\Contracts\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Taylor Otwell",
-                    "email": "taylor@laravel.com"
-                }
-            ],
-            "description": "The Illuminate Contracts package.",
-            "homepage": "http://laravel.com",
-            "time": "2016-08-08T11:46:08+00:00"
-        },
-        {
-            "name": "illuminate/database",
-            "version": "v5.2.45",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/illuminate/database.git",
-                "reference": "4a70c0598ed41d18a99f23c12be4e22b5006d30a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/database/zipball/4a70c0598ed41d18a99f23c12be4e22b5006d30a",
-                "reference": "4a70c0598ed41d18a99f23c12be4e22b5006d30a",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/container": "5.2.*",
-                "illuminate/contracts": "5.2.*",
-                "illuminate/support": "5.2.*",
-                "nesbot/carbon": "~1.20",
-                "php": ">=5.5.9"
-            },
-            "suggest": {
-                "doctrine/dbal": "Required to rename columns and drop SQLite columns (~2.4).",
-                "fzaninotto/faker": "Required to use the eloquent factory builder (~1.4).",
-                "illuminate/console": "Required to use the database commands (5.2.*).",
-                "illuminate/events": "Required to use the observers with Eloquent (5.2.*).",
-                "illuminate/filesystem": "Required to use the migrations (5.2.*).",
-                "illuminate/pagination": "Required to paginate the result set (5.2.*)."
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Illuminate\\Database\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Taylor Otwell",
-                    "email": "taylor@laravel.com"
-                }
-            ],
-            "description": "The Illuminate Database package.",
-            "homepage": "http://laravel.com",
-            "keywords": [
-                "database",
-                "laravel",
-                "orm",
-                "sql"
-            ],
-            "time": "2016-08-25T07:01:20+00:00"
-        },
-        {
-            "name": "illuminate/filesystem",
-            "version": "v5.2.45",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/illuminate/filesystem.git",
-                "reference": "39668a50e0cf1d673e58e7dbb437475708cfb508"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/39668a50e0cf1d673e58e7dbb437475708cfb508",
-                "reference": "39668a50e0cf1d673e58e7dbb437475708cfb508",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/contracts": "5.2.*",
-                "illuminate/support": "5.2.*",
-                "php": ">=5.5.9",
-                "symfony/finder": "2.8.*|3.0.*"
-            },
-            "suggest": {
-                "league/flysystem": "Required to use the Flysystem local and FTP drivers (~1.0).",
-                "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (~1.0).",
-                "league/flysystem-rackspace": "Required to use the Flysystem Rackspace driver (~1.0)."
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Illuminate\\Filesystem\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Taylor Otwell",
-                    "email": "taylor@laravel.com"
-                }
-            ],
-            "description": "The Illuminate Filesystem package.",
-            "homepage": "http://laravel.com",
-            "time": "2016-08-17T17:21:29+00:00"
-        },
-        {
-            "name": "illuminate/support",
-            "version": "v5.2.45",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/illuminate/support.git",
-                "reference": "510230ab62a7d85dc70203f4fdca6fb71a19e08a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/510230ab62a7d85dc70203f4fdca6fb71a19e08a",
-                "reference": "510230ab62a7d85dc70203f4fdca6fb71a19e08a",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/inflector": "~1.0",
-                "ext-mbstring": "*",
-                "illuminate/contracts": "5.2.*",
-                "paragonie/random_compat": "~1.4",
-                "php": ">=5.5.9"
-            },
-            "replace": {
-                "tightenco/collect": "self.version"
-            },
-            "suggest": {
-                "illuminate/filesystem": "Required to use the composer class (5.2.*).",
-                "jeremeamia/superclosure": "Required to be able to serialize closures (~2.2).",
-                "symfony/polyfill-php56": "Required to use the hash_equals function on PHP 5.5 (~1.0).",
-                "symfony/process": "Required to use the composer class (2.8.*|3.0.*).",
-                "symfony/var-dumper": "Improves the dd function (2.8.*|3.0.*)."
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Illuminate\\Support\\": ""
-                },
-                "files": [
-                    "helpers.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Taylor Otwell",
-                    "email": "taylor@laravel.com"
-                }
-            ],
-            "description": "The Illuminate Support package.",
-            "homepage": "http://laravel.com",
-            "time": "2016-08-05T14:49:58+00:00"
+            "time": "2012-08-31 00:00:00"
         },
         {
             "name": "jgrossi/corcel",
-            "version": "v2.2.0",
+            "version": "v2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/corcel/corcel.git",
-                "reference": "d4e0ffd912c4e28effc61ce47e1475de5f52809b"
+                "reference": "c351f11af7a24d697342d0027532c8cbd8dd7fd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/corcel/corcel/zipball/d4e0ffd912c4e28effc61ce47e1475de5f52809b",
-                "reference": "d4e0ffd912c4e28effc61ce47e1475de5f52809b",
+                "url": "https://api.github.com/repos/corcel/corcel/zipball/c351f11af7a24d697342d0027532c8cbd8dd7fd6",
+                "reference": "c351f11af7a24d697342d0027532c8cbd8dd7fd6",
                 "shasum": ""
             },
             "require": {
                 "fzaninotto/faker": "^1.6",
                 "hautelook/phpass": "0.3.4",
-                "illuminate/database": "5.2.*",
-                "illuminate/filesystem": "5.2.*",
-                "illuminate/support": "5.2.*",
-                "php": ">=5.5.9",
+                "illuminate/database": "~5.4.0",
+                "illuminate/filesystem": "~5.4.0",
+                "illuminate/support": "~5.4.0",
+                "php": ">=5.6.4",
                 "thunderer/shortcode": "^0.6.2"
             },
             "replace": {
                 "juniorgrossi/corcel": "self.version"
             },
             "require-dev": {
-                "orchestra/database": "~3.2.0",
-                "orchestra/testbench": "~3.2.0",
+                "orchestra/database": "~3.4.0",
+                "orchestra/testbench": "~3.4.0",
                 "phpunit/phpunit": "~4.8",
                 "satooshi/php-coveralls": "dev-master"
             },
@@ -471,7 +265,342 @@
             ],
             "description": "Use WordPress backend with Laravel or any PHP framework",
             "homepage": "http://github.com/corcel/corcel",
-            "time": "2017-07-27T17:07:57+00:00"
+            "time": "2017-08-19 17:47:24"
+        },
+        {
+            "name": "laravel/framework",
+            "version": "v5.4.36",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/framework.git",
+                "reference": "1062a22232071c3e8636487c86ec1ae75681bbf9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/1062a22232071c3e8636487c86ec1ae75681bbf9",
+                "reference": "1062a22232071c3e8636487c86ec1ae75681bbf9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/inflector": "~1.1",
+                "erusev/parsedown": "~1.6",
+                "ext-mbstring": "*",
+                "ext-openssl": "*",
+                "league/flysystem": "~1.0",
+                "monolog/monolog": "~1.11",
+                "mtdowling/cron-expression": "~1.0",
+                "nesbot/carbon": "~1.20",
+                "paragonie/random_compat": "~1.4|~2.0",
+                "php": ">=5.6.4",
+                "ramsey/uuid": "~3.0",
+                "swiftmailer/swiftmailer": "~5.4",
+                "symfony/console": "~3.2",
+                "symfony/debug": "~3.2",
+                "symfony/finder": "~3.2",
+                "symfony/http-foundation": "~3.2",
+                "symfony/http-kernel": "~3.2",
+                "symfony/process": "~3.2",
+                "symfony/routing": "~3.2",
+                "symfony/var-dumper": "~3.2",
+                "tijsverkoyen/css-to-inline-styles": "~2.2",
+                "vlucas/phpdotenv": "~2.2"
+            },
+            "replace": {
+                "illuminate/auth": "self.version",
+                "illuminate/broadcasting": "self.version",
+                "illuminate/bus": "self.version",
+                "illuminate/cache": "self.version",
+                "illuminate/config": "self.version",
+                "illuminate/console": "self.version",
+                "illuminate/container": "self.version",
+                "illuminate/contracts": "self.version",
+                "illuminate/cookie": "self.version",
+                "illuminate/database": "self.version",
+                "illuminate/encryption": "self.version",
+                "illuminate/events": "self.version",
+                "illuminate/exception": "self.version",
+                "illuminate/filesystem": "self.version",
+                "illuminate/hashing": "self.version",
+                "illuminate/http": "self.version",
+                "illuminate/log": "self.version",
+                "illuminate/mail": "self.version",
+                "illuminate/notifications": "self.version",
+                "illuminate/pagination": "self.version",
+                "illuminate/pipeline": "self.version",
+                "illuminate/queue": "self.version",
+                "illuminate/redis": "self.version",
+                "illuminate/routing": "self.version",
+                "illuminate/session": "self.version",
+                "illuminate/support": "self.version",
+                "illuminate/translation": "self.version",
+                "illuminate/validation": "self.version",
+                "illuminate/view": "self.version",
+                "tightenco/collect": "self.version"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "~3.0",
+                "doctrine/dbal": "~2.5",
+                "mockery/mockery": "~0.9.4",
+                "pda/pheanstalk": "~3.0",
+                "phpunit/phpunit": "~5.7",
+                "predis/predis": "~1.0",
+                "symfony/css-selector": "~3.2",
+                "symfony/dom-crawler": "~3.2"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Required to use the SQS queue driver and SES mail driver (~3.0).",
+                "doctrine/dbal": "Required to rename columns and drop SQLite columns (~2.5).",
+                "fzaninotto/faker": "Required to use the eloquent factory builder (~1.4).",
+                "guzzlehttp/guzzle": "Required to use the Mailgun and Mandrill mail drivers and the ping methods on schedules (~6.0).",
+                "laravel/tinker": "Required to use the tinker console command (~1.0).",
+                "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (~1.0).",
+                "league/flysystem-rackspace": "Required to use the Flysystem Rackspace driver (~1.0).",
+                "nexmo/client": "Required to use the Nexmo transport (~1.0).",
+                "pda/pheanstalk": "Required to use the beanstalk queue driver (~3.0).",
+                "predis/predis": "Required to use the redis cache and queue drivers (~1.0).",
+                "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (~2.0).",
+                "symfony/css-selector": "Required to use some of the crawler integration testing tools (~3.2).",
+                "symfony/dom-crawler": "Required to use most of the crawler integration testing tools (~3.2).",
+                "symfony/psr-http-message-bridge": "Required to psr7 bridging features (0.2.*)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.4-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Illuminate/Foundation/helpers.php",
+                    "src/Illuminate/Support/helpers.php"
+                ],
+                "psr-4": {
+                    "Illuminate\\": "src/Illuminate/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Laravel Framework.",
+            "homepage": "https://laravel.com",
+            "keywords": [
+                "framework",
+                "laravel"
+            ],
+            "time": "2017-08-30 09:26:16"
+        },
+        {
+            "name": "league/flysystem",
+            "version": "1.0.42",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem.git",
+                "reference": "09eabc54e199950041aef258a85847676496fe8e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/09eabc54e199950041aef258a85847676496fe8e",
+                "reference": "09eabc54e199950041aef258a85847676496fe8e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "conflict": {
+                "league/flysystem-sftp": "<1.0.6"
+            },
+            "require-dev": {
+                "ext-fileinfo": "*",
+                "phpspec/phpspec": "^3.4",
+                "phpunit/phpunit": "^5.7"
+            },
+            "suggest": {
+                "ext-fileinfo": "Required for MimeType",
+                "ext-ftp": "Allows you to use FTP server storage",
+                "ext-openssl": "Allows you to use FTPS server storage",
+                "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
+                "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
+                "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
+                "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
+                "league/flysystem-eventable-filesystem": "Allows you to use EventableFilesystem",
+                "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
+                "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
+                "league/flysystem-webdav": "Allows you to use WebDAV storage",
+                "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter",
+                "spatie/flysystem-dropbox": "Allows you to use Dropbox storage",
+                "srmklive/flysystem-dropbox-v2": "Allows you to use Dropbox storage for PHP 5 applications"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Filesystem abstraction: Many filesystems, one API.",
+            "keywords": [
+                "Cloud Files",
+                "WebDAV",
+                "abstraction",
+                "aws",
+                "cloud",
+                "copy.com",
+                "dropbox",
+                "file systems",
+                "files",
+                "filesystem",
+                "filesystems",
+                "ftp",
+                "rackspace",
+                "remote",
+                "s3",
+                "sftp",
+                "storage"
+            ],
+            "time": "2018-01-27 16:03:56"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
+                "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "psr/log": "~1.0"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "graylog2/gelf-php": "~1.0",
+                "jakub-onderka/php-parallel-lint": "0.9",
+                "php-amqplib/php-amqplib": "~2.4",
+                "php-console/php-console": "^3.1.3",
+                "phpunit/phpunit": "~4.5",
+                "phpunit/phpunit-mock-objects": "2.3.0",
+                "ruflin/elastica": ">=0.90 <3.0",
+                "sentry/sentry": "^0.13",
+                "swiftmailer/swiftmailer": "^5.3|^6.0"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-mongo": "Allow sending log messages to a MongoDB server",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "php-console/php-console": "Allow sending log messages to Google Chrome",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                "sentry/sentry": "Allow sending log messages to a Sentry server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "http://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "time": "2017-06-19 01:22:40"
+        },
+        {
+            "name": "mtdowling/cron-expression",
+            "version": "v1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mtdowling/cron-expression.git",
+                "reference": "9504fa9ea681b586028adaaa0877db4aecf32bad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mtdowling/cron-expression/zipball/9504fa9ea681b586028adaaa0877db4aecf32bad",
+                "reference": "9504fa9ea681b586028adaaa0877db4aecf32bad",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0|~5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cron\\": "src/Cron/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "CRON for PHP: Calculate the next or previous run date and determine if a CRON expression is due",
+            "keywords": [
+                "cron",
+                "schedule"
+            ],
+            "time": "2017-01-23 04:29:33"
         },
         {
             "name": "nesbot/carbon",
@@ -524,20 +653,20 @@
                 "datetime",
                 "time"
             ],
-            "time": "2017-01-16T07:55:07+00:00"
+            "time": "2017-01-16 07:55:07"
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v1.4.2",
+            "version": "v2.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "965cdeb01fdcab7653253aa81d40441d261f1e66"
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/965cdeb01fdcab7653253aa81d40441d261f1e66",
-                "reference": "965cdeb01fdcab7653253aa81d40441d261f1e66",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/5da4d3c796c275c55f057af5a643ae297d96b4d8",
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8",
                 "shasum": ""
             },
             "require": {
@@ -572,29 +701,451 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2017-03-13T16:22:52+00:00"
+            "time": "2017-09-27 21:40:39"
         },
         {
-            "name": "symfony/finder",
-            "version": "v3.0.9",
+            "name": "psr/log",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "3eb4e64c6145ef8b92adefb618a74ebdde9e3fe9"
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/3eb4e64c6145ef8b92adefb618a74ebdde9e3fe9",
-                "reference": "3eb4e64c6145ef8b92adefb618a74ebdde9e3fe9",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": ">=5.3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2016-10-10 12:19:37"
+        },
+        {
+            "name": "ramsey/uuid",
+            "version": "3.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/uuid.git",
+                "reference": "44abcdad877d9a46685a3a4d221e3b2c4b87cb76"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/44abcdad877d9a46685a3a4d221e3b2c4b87cb76",
+                "reference": "44abcdad877d9a46685a3a4d221e3b2c4b87cb76",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/random_compat": "^1.0|^2.0",
+                "php": "^5.4 || ^7.0"
+            },
+            "replace": {
+                "rhumsaa/uuid": "self.version"
+            },
+            "require-dev": {
+                "codeception/aspect-mock": "^1.0 | ~2.0.0",
+                "doctrine/annotations": "~1.2.0",
+                "goaop/framework": "1.0.0-alpha.2 | ^1.0 | ^2.1",
+                "ircmaxell/random-lib": "^1.1",
+                "jakub-onderka/php-parallel-lint": "^0.9.0",
+                "mockery/mockery": "^0.9.9",
+                "moontoast/math": "^1.1",
+                "php-mock/php-mock-phpunit": "^0.3|^1.1",
+                "phpunit/phpunit": "^4.7|^5.0",
+                "squizlabs/php_codesniffer": "^2.3"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides the PECL libsodium extension for use with the SodiumRandomGenerator",
+                "ext-uuid": "Provides the PECL UUID extension for use with the PeclUuidTimeGenerator and PeclUuidRandomGenerator",
+                "ircmaxell/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
+                "moontoast/math": "Provides support for converting UUID to 128-bit integer (in string form).",
+                "ramsey/uuid-console": "A console application for generating UUIDs with ramsey/uuid",
+                "ramsey/uuid-doctrine": "Allows the use of Ramsey\\Uuid\\Uuid as Doctrine field type."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ramsey\\Uuid\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marijn Huizendveld",
+                    "email": "marijn.huizendveld@gmail.com"
+                },
+                {
+                    "name": "Thibaud Fabre",
+                    "email": "thibaud@aztech.io"
+                },
+                {
+                    "name": "Ben Ramsey",
+                    "email": "ben@benramsey.com",
+                    "homepage": "https://benramsey.com"
+                }
+            ],
+            "description": "Formerly rhumsaa/uuid. A PHP 5.4+ library for generating RFC 4122 version 1, 3, 4, and 5 universally unique identifiers (UUID).",
+            "homepage": "https://github.com/ramsey/uuid",
+            "keywords": [
+                "guid",
+                "identifier",
+                "uuid"
+            ],
+            "time": "2018-01-20 00:28:24"
+        },
+        {
+            "name": "swiftmailer/swiftmailer",
+            "version": "v5.4.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swiftmailer/swiftmailer.git",
+                "reference": "7ffc1ea296ed14bf8260b6ef11b80208dbadba91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/7ffc1ea296ed14bf8260b6ef11b80208dbadba91",
+                "reference": "7ffc1ea296ed14bf8260b6ef11b80208dbadba91",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "mockery/mockery": "~0.9.1",
+                "symfony/phpunit-bridge": "~3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.4-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "lib/swift_required.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Corbyn"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Swiftmailer, free feature-rich PHP mailer",
+            "homepage": "https://swiftmailer.symfony.com",
+            "keywords": [
+                "email",
+                "mail",
+                "mailer"
+            ],
+            "time": "2018-01-23 07:37:21"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "26b6f419edda16c19775211987651cb27baea7f1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/26b6f419edda16c19775211987651cb27baea7f1",
+                "reference": "26b6f419edda16c19775211987651cb27baea7f1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/debug": "~2.8|~3.0|~4.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4",
+                "symfony/process": "<3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~3.3|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
+                "symfony/lock": "~3.4|~4.0",
+                "symfony/process": "~3.3|~4.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-01-29 09:03:43"
+        },
+        {
+            "name": "symfony/css-selector",
+            "version": "v3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/css-selector.git",
+                "reference": "e66394bc7610e69279bfdb3ab11b4fe65403f556"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/e66394bc7610e69279bfdb3ab11b4fe65403f556",
+                "reference": "e66394bc7610e69279bfdb3ab11b4fe65403f556",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\CssSelector\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jean-François Simon",
+                    "email": "jeanfrancois.simon@sensiolabs.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony CssSelector Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-01-03 07:37:34"
+        },
+        {
+            "name": "symfony/debug",
+            "version": "v3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "53f6af2805daf52a43b393b93d2f24925d35c937"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/53f6af2805daf52a43b393b93d2f24925d35c937",
+                "reference": "53f6af2805daf52a43b393b93d2f24925d35c937",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "psr/log": "~1.0"
+            },
+            "conflict": {
+                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
+            },
+            "require-dev": {
+                "symfony/http-kernel": "~2.8|~3.0|~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Debug\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Debug Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-01-18 22:16:57"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "26b87b6bca8f8f797331a30b76fdae5342dc26ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/26b87b6bca8f8f797331a30b76fdae5342dc26ca",
+                "reference": "26b87b6bca8f8f797331a30b76fdae5342dc26ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.8|~3.0|~4.0",
+                "symfony/dependency-injection": "~3.3|~4.0",
+                "symfony/expression-language": "~2.8|~3.0|~4.0",
+                "symfony/stopwatch": "~2.8|~3.0|~4.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-01-03 07:37:34"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "613e26310776f49a1773b6737c6bd554b8bc8c6f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/613e26310776f49a1773b6737c6bd554b8bc8c6f",
+                "reference": "613e26310776f49a1773b6737c6bd554b8bc8c6f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -621,20 +1172,162 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29T05:40:00+00:00"
+            "time": "2018-01-03 07:37:34"
         },
         {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.4.0",
+            "name": "symfony/http-foundation",
+            "version": "v3.4.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "f29dca382a6485c3cbe6379f0c61230167681937"
+                "url": "https://github.com/symfony/http-foundation.git",
+                "reference": "8c39071ac9cc7e6d8dab1d556c990dc0d2cc3d30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/f29dca382a6485c3cbe6379f0c61230167681937",
-                "reference": "f29dca382a6485c3cbe6379f0c61230167681937",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/8c39071ac9cc7e6d8dab1d556c990dc0d2cc3d30",
+                "reference": "8c39071ac9cc7e6d8dab1d556c990dc0d2cc3d30",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/polyfill-mbstring": "~1.1",
+                "symfony/polyfill-php70": "~1.6"
+            },
+            "require-dev": {
+                "symfony/expression-language": "~2.8|~3.0|~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpFoundation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony HttpFoundation Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-01-29 09:03:43"
+        },
+        {
+            "name": "symfony/http-kernel",
+            "version": "v3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-kernel.git",
+                "reference": "911d2e5dd4beb63caad9a72e43857de984301907"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/911d2e5dd4beb63caad9a72e43857de984301907",
+                "reference": "911d2e5dd4beb63caad9a72e43857de984301907",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "psr/log": "~1.0",
+                "symfony/debug": "~2.8|~3.0|~4.0",
+                "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
+                "symfony/http-foundation": "^3.4.4|^4.0.4"
+            },
+            "conflict": {
+                "symfony/config": "<2.8",
+                "symfony/dependency-injection": "<3.4",
+                "symfony/var-dumper": "<3.3",
+                "twig/twig": "<1.34|<2.4,>=2"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
+            "require-dev": {
+                "psr/cache": "~1.0",
+                "symfony/browser-kit": "~2.8|~3.0|~4.0",
+                "symfony/class-loader": "~2.8|~3.0",
+                "symfony/config": "~2.8|~3.0|~4.0",
+                "symfony/console": "~2.8|~3.0|~4.0",
+                "symfony/css-selector": "~2.8|~3.0|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/dom-crawler": "~2.8|~3.0|~4.0",
+                "symfony/expression-language": "~2.8|~3.0|~4.0",
+                "symfony/finder": "~2.8|~3.0|~4.0",
+                "symfony/process": "~2.8|~3.0|~4.0",
+                "symfony/routing": "~3.4|~4.0",
+                "symfony/stopwatch": "~2.8|~3.0|~4.0",
+                "symfony/templating": "~2.8|~3.0|~4.0",
+                "symfony/translation": "~2.8|~3.0|~4.0",
+                "symfony/var-dumper": "~3.3|~4.0"
+            },
+            "suggest": {
+                "symfony/browser-kit": "",
+                "symfony/config": "",
+                "symfony/console": "",
+                "symfony/dependency-injection": "",
+                "symfony/finder": "",
+                "symfony/var-dumper": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpKernel\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony HttpKernel Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-01-29 12:29:46"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/78be803ce01e55d3491c1397cf1c64beb9c1b63b",
+                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b",
                 "shasum": ""
             },
             "require": {
@@ -646,7 +1339,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "1.7-dev"
                 }
             },
             "autoload": {
@@ -680,35 +1373,224 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-09T14:24:12+00:00"
+            "time": "2018-01-30 19:27:44"
         },
         {
-            "name": "symfony/translation",
-            "version": "v3.3.6",
+            "name": "symfony/polyfill-php70",
+            "version": "v1.7.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/translation.git",
-                "reference": "35dd5fb003c90e8bd4d8cabdf94bf9c96d06fdc3"
+                "url": "https://github.com/symfony/polyfill-php70.git",
+                "reference": "3532bfcd8f933a7816f3a0a59682fc404776600f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/35dd5fb003c90e8bd4d8cabdf94bf9c96d06fdc3",
-                "reference": "35dd5fb003c90e8bd4d8cabdf94bf9c96d06fdc3",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/3532bfcd8f933a7816f3a0a59682fc404776600f",
+                "reference": "3532bfcd8f933a7816f3a0a59682fc404776600f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
+                "paragonie/random_compat": "~1.0|~2.0",
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php70\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-01-30 19:27:44"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "09a5172057be8fc677840e591b17f385e58c7c0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/09a5172057be8fc677840e591b17f385e58c7c0d",
+                "reference": "09a5172057be8fc677840e591b17f385e58c7c0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-01-29 09:03:43"
+        },
+        {
+            "name": "symfony/routing",
+            "version": "v3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/routing.git",
+                "reference": "235d01730d553a97732990588407eaf6779bb4b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/235d01730d553a97732990588407eaf6779bb4b2",
+                "reference": "235d01730d553a97732990588407eaf6779bb4b2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "conflict": {
+                "symfony/config": "<2.8",
+                "symfony/dependency-injection": "<3.3",
+                "symfony/yaml": "<3.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "doctrine/common": "~2.2",
+                "psr/log": "~1.0",
+                "symfony/config": "~2.8|~3.0|~4.0",
+                "symfony/dependency-injection": "~3.3|~4.0",
+                "symfony/expression-language": "~2.8|~3.0|~4.0",
+                "symfony/http-foundation": "~2.8|~3.0|~4.0",
+                "symfony/yaml": "~3.4|~4.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "For using the annotation loader",
+                "symfony/config": "For using the all-in-one router or any loader",
+                "symfony/dependency-injection": "For loading routes from a service",
+                "symfony/expression-language": "For using expression matching",
+                "symfony/http-foundation": "For using a Symfony Request object",
+                "symfony/yaml": "For using the YAML loader"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Routing\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Routing Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "router",
+                "routing",
+                "uri",
+                "url"
+            ],
+            "time": "2018-01-16 18:03:57"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "10b32cf0eae28b9b39fe26c456c42b19854c4b84"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/10b32cf0eae28b9b39fe26c456c42b19854c4b84",
+                "reference": "10b32cf0eae28b9b39fe26c456c42b19854c4b84",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
                 "symfony/config": "<2.8",
-                "symfony/yaml": "<3.3"
+                "symfony/dependency-injection": "<3.4",
+                "symfony/yaml": "<3.4"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.8|~3.0",
-                "symfony/intl": "^2.8.18|^3.2.5",
-                "symfony/yaml": "~3.3"
+                "symfony/config": "~2.8|~3.0|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/finder": "~2.8|~3.0|~4.0",
+                "symfony/intl": "^2.8.18|^3.2.5|~4.0",
+                "symfony/yaml": "~3.4|~4.0"
             },
             "suggest": {
                 "psr/log": "To use logging capability in translator",
@@ -718,7 +1600,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -745,7 +1627,76 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-24T16:45:30+00:00"
+            "time": "2018-01-18 22:16:57"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "472a9849930cf21f73abdb02240f17cf5b5bd1a7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/472a9849930cf21f73abdb02240f17cf5b5bd1a7",
+                "reference": "472a9849930cf21f73abdb02240f17cf5b5bd1a7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+            },
+            "require-dev": {
+                "ext-iconv": "*",
+                "twig/twig": "~1.34|~2.4"
+            },
+            "suggest": {
+                "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
+                "ext-intl": "To show region name in time zone dump",
+                "ext-symfony_debug": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony mechanism for exploring and dumping PHP variables",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "time": "2018-01-29 09:03:43"
         },
         {
             "name": "thunderer/shortcode",
@@ -797,7 +1748,104 @@
                 "parser",
                 "shortcode"
             ],
-            "time": "2017-01-08T00:22:37+00:00"
+            "time": "2017-01-08 00:22:37"
+        },
+        {
+            "name": "tijsverkoyen/css-to-inline-styles",
+            "version": "2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tijsverkoyen/CssToInlineStyles.git",
+                "reference": "0ed4a2ea4e0902dac0489e6436ebcd5bbcae9757"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/0ed4a2ea4e0902dac0489e6436ebcd5bbcae9757",
+                "reference": "0ed4a2ea4e0902dac0489e6436ebcd5bbcae9757",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "symfony/css-selector": "^2.7 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "TijsVerkoyen\\CssToInlineStyles\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Tijs Verkoyen",
+                    "email": "css_to_inline_styles@verkoyen.eu",
+                    "role": "Developer"
+                }
+            ],
+            "description": "CssToInlineStyles is a class that enables you to convert HTML-pages/files into HTML-pages/files with inline styles. This is very useful when you're sending emails.",
+            "homepage": "https://github.com/tijsverkoyen/CssToInlineStyles",
+            "time": "2017-11-27 11:13:29"
+        },
+        {
+            "name": "vlucas/phpdotenv",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vlucas/phpdotenv.git",
+                "reference": "3cc116adbe4b11be5ec557bf1d24dc5e3a21d18c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/3cc116adbe4b11be5ec557bf1d24dc5e3a21d18c",
+                "reference": "3cc116adbe4b11be5ec557bf1d24dc5e3a21d18c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dotenv\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause-Attribution"
+            ],
+            "authors": [
+                {
+                    "name": "Vance Lucas",
+                    "email": "vance@vancelucas.com",
+                    "homepage": "http://www.vancelucas.com"
+                }
+            ],
+            "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "time": "2016-09-01 10:05:43"
         }
     ],
     "packages-dev": [
@@ -853,20 +1901,346 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2015-06-14 21:17:01"
         },
         {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0",
+            "name": "myclabs/deep-copy",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2017-10-19 19:58:43"
+        },
+        {
+            "name": "orchestra/database",
+            "version": "v3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/orchestral/database.git",
+                "reference": "2bc4ab6e683398d8c98d28fb7f3e91887658834c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/orchestral/database/zipball/2bc4ab6e683398d8c98d28fb7f3e91887658834c",
+                "reference": "2bc4ab6e683398d8c98d28fb7f3e91887658834c",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "~5.4.0",
+                "illuminate/database": "~5.4.17",
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Orchestra\\Database\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mior Muhammad Zaki",
+                    "email": "crynobone@gmail.com",
+                    "homepage": "https://github.com/crynobone"
+                },
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylorotwell@gmail.com",
+                    "homepage": "https://github.com/taylorotwell"
+                }
+            ],
+            "description": "Database Component for Orchestra Platform",
+            "keywords": [
+                "database",
+                "orchestra-platform",
+                "orchestral"
+            ],
+            "time": "2017-08-25 10:03:18"
+        },
+        {
+            "name": "orchestra/testbench",
+            "version": "v3.4.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/orchestral/testbench.git",
+                "reference": "3f4f3a129fa315d65f6827b3eeb89c4190e19d19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/orchestral/testbench/zipball/3f4f3a129fa315d65f6827b3eeb89c4190e19d19",
+                "reference": "3f4f3a129fa315d65f6827b3eeb89c4190e19d19",
+                "shasum": ""
+            },
+            "require": {
+                "fzaninotto/faker": "~1.4",
+                "laravel/framework": "~5.4.17",
+                "orchestra/testbench-core": "~3.4.4",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "orchestra/database": "~3.4.0",
+                "phpunit/phpunit": "~5.7"
+            },
+            "suggest": {
+                "mockery/mockery": "Allow to use Mockery for testing (^0.9.4).",
+                "orchestra/database": "Allow to use --realpath migration for testing (~3.4).",
+                "orchestra/testbench-browser-kit": "Allow to use legacy BrowserKit for testing (~3.4).",
+                "phpunit/phpunit": "Allow to use PHPUnit for testing (~5.7)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mior Muhammad Zaki",
+                    "email": "crynobone@gmail.com",
+                    "homepage": "https://github.com/crynobone"
+                }
+            ],
+            "description": "Laravel Testing Helper for Packages Development",
+            "homepage": "http://orchestraplatform.com/docs/latest/components/testbench/",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "laravel",
+                "orchestra-platform",
+                "orchestral",
+                "testing"
+            ],
+            "time": "2017-10-08 07:55:54"
+        },
+        {
+            "name": "orchestra/testbench-core",
+            "version": "v3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/orchestral/testbench-core.git",
+                "reference": "3533c7477b077afa8fc069979e3afde72a806698"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/3533c7477b077afa8fc069979e3afde72a806698",
+                "reference": "3533c7477b077afa8fc069979e3afde72a806698",
+                "shasum": ""
+            },
+            "require": {
+                "fzaninotto/faker": "~1.4",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "laravel/framework": "~5.4.17",
+                "mockery/mockery": "^0.9.4",
+                "orchestra/database": "~3.4.0",
+                "phpunit/phpunit": "~5.7 || ~6.0"
+            },
+            "suggest": {
+                "laravel/framework": "Required for testing (~5.4.0).",
+                "mockery/mockery": "Allow to use Mockery for testing (^0.9.4).",
+                "orchestra/database": "Allow to use --realpath migration for testing (~3.4).",
+                "orchestra/testbench-browser-kit": "Allow to use legacy BrowserKit for testing (~3.4).",
+                "phpunit/phpunit": "Allow to use PHPUnit for testing (~6.0)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Orchestra\\Testbench\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mior Muhammad Zaki",
+                    "email": "crynobone@gmail.com",
+                    "homepage": "https://github.com/crynobone"
+                }
+            ],
+            "description": "Testing Helper for Laravel Development",
+            "homepage": "http://orchestraplatform.com/docs/latest/components/testbench/",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "laravel",
+                "orchestra-platform",
+                "orchestral",
+                "testing"
+            ],
+            "time": "2017-10-08 07:39:49"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^1.0.1",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2017-03-05 18:14:27"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2017-03-05 17:38:23"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
                 "shasum": ""
             },
             "require": {
@@ -907,33 +2281,39 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27T11:43:31+00:00"
+            "time": "2017-09-11 18:02:19"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.2.1",
+            "version": "4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "183824db76118b9dddffc7e522b91fa175f75119"
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/183824db76118b9dddffc7e522b91fa175f75119",
-                "reference": "183824db76118b9dddffc7e522b91fa175f75119",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.3.0",
+                "php": "^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "phpDocumentor\\Reflection\\": [
@@ -952,20 +2332,20 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-04T20:55:59+00:00"
+            "time": "2017-11-30 07:14:17"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.3.0",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773"
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/fb3933512008d8162b3cdf9e18dba9309b7c3773",
-                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
                 "shasum": ""
             },
             "require": {
@@ -999,37 +2379,37 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-06-03T08:32:36+00:00"
+            "time": "2017-07-14 14:27:02"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.0",
+            "version": "1.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
+                "reference": "9f901e29c93dae4aa77c0bb161df4276f9c9a1be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/9f901e29c93dae4aa77c0bb161df4276f9c9a1be",
+                "reference": "9f901e29c93dae4aa77c0bb161df4276f9c9a1be",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
                 "sebastian/comparator": "^1.1|^2.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.7.x-dev"
                 }
             },
             "autoload": {
@@ -1062,43 +2442,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02T20:05:34+00:00"
+            "time": "2018-02-11 18:49:29"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.4",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/661f34d0bd3f1a7225ef491a70a020ad23a057a1",
+                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0",
+                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^2.0.1",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
-                "ext-xmlwriter": "*"
+                "ext-xdebug": "^2.5.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-master": "5.3.x-dev"
                 }
             },
             "autoload": {
@@ -1113,7 +2494,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1124,20 +2505,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06T15:47:00+00:00"
+            "time": "2017-12-06 09:29:45"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -1171,7 +2552,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2017-11-27 13:52:08"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1212,7 +2593,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21T13:50:34+00:00"
+            "time": "2015-06-21 13:50:34"
         },
         {
             "name": "phpunit/php-timer",
@@ -1261,33 +2642,33 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
+            "time": "2017-02-26 11:10:40"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.11",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
+                "reference": "791198a2c6254db10131eecfe8c06670700904db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
+                "reference": "791198a2c6254db10131eecfe8c06670700904db",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1310,45 +2691,57 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-27T10:12:30+00:00"
+            "time": "2017-11-27 05:48:46"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.36",
+            "version": "6.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517"
+                "reference": "3330ef26ade05359d006041316ed0fa9e8e3cefe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/46023de9a91eec7dfb06cc56cb4e260017298517",
-                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3330ef26ade05359d006041316ed0fa9e8e3cefe",
+                "reference": "3330ef26ade05359d006041316ed0fa9e8e3cefe",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.2.2",
-                "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
-                "symfony/yaml": "~2.1|~3.0"
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "^1.6.1",
+                "phar-io/manifest": "^1.0.1",
+                "phar-io/version": "^1.0",
+                "php": "^7.0",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^5.3",
+                "phpunit/php-file-iterator": "^1.4.3",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^1.0.9",
+                "phpunit/phpunit-mock-objects": "^5.0.5",
+                "sebastian/comparator": "^2.1",
+                "sebastian/diff": "^2.0",
+                "sebastian/environment": "^3.1",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^1.0",
+                "sebastian/version": "^2.0.1"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2",
+                "phpunit/dbunit": "<3.0"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
             },
             "suggest": {
-                "phpunit/php-invoker": "~1.1"
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "^1.1"
             },
             "bin": [
                 "phpunit"
@@ -1356,7 +2749,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8.x-dev"
+                    "dev-master": "6.5.x-dev"
                 }
             },
             "autoload": {
@@ -1382,30 +2775,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-06-21T08:07:12+00:00"
+            "time": "2018-02-01 05:57:37"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.8",
+            "version": "5.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
+                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "doctrine/instantiator": "^1.0.5",
+                "php": "^7.0",
+                "phpunit/php-text-template": "^1.2.1",
+                "sebastian/exporter": "^3.1"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.5"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -1413,7 +2809,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev"
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "autoload": {
@@ -1428,7 +2824,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1438,34 +2834,79 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02T06:51:40+00:00"
+            "time": "2018-01-06 05:45:45"
         },
         {
-            "name": "sebastian/comparator",
-            "version": "1.2.4",
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2 || ~2.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2017-03-04 06:30:41"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "2.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/diff": "^2.0 || ^3.0",
+                "sebastian/exporter": "^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -1496,38 +2937,38 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29T09:50:25+00:00"
+            "time": "2018-02-01 13:46:46"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.3",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^6.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1554,32 +2995,32 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2017-05-22T07:24:03+00:00"
+            "time": "2017-08-03 08:09:46"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.8",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8 || ^5.0"
+                "phpunit/phpunit": "^6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -1604,34 +3045,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18T05:49:44+00:00"
+            "time": "2017-07-01 08:51:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.2",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -1671,27 +3112,27 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17T09:04:28+00:00"
+            "time": "2017-04-03 13:19:02"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1699,7 +3140,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1722,32 +3163,124 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2017-04-27 15:39:26"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "1.0.5",
+            "name": "sebastian/object-enumerator",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7"
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
-                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-08-03 12:35:26"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29 09:07:27"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1775,23 +3308,73 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-10-03T07:41:43+00:00"
+            "time": "2017-03-03 06:23:57"
         },
         {
-            "name": "sebastian/version",
-            "version": "1.0.6",
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.6.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28 20:34:47"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1810,75 +3393,60 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21T13:59:46+00:00"
+            "time": "2016-10-03 07:35:21"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v3.3.6",
+            "name": "theseer/tokenizer",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "ddc23324e6cfe066f3dd34a37ff494fa80b617ed"
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/ddc23324e6cfe066f3dd34a37ff494fa80b617ed",
-                "reference": "ddc23324e6cfe066f3dd34a37ff494fa80b617ed",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
-            },
-            "require-dev": {
-                "symfony/console": "~2.8|~3.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.3-dev"
-                }
-            },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 }
             ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2017-07-23T12:43:26+00:00"
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2017-04-07 12:08:54"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
                 "shasum": ""
             },
             "require": {
@@ -1915,7 +3483,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2018-01-29 19:49:41"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "242a7fcc0edad52371caf6d44d5ec72b",
-    "content-hash": "3f58b9879134d84c78bbe8a27ab8fe4f",
+    "hash": "f325f0cdb435f7f0cbc62b1b7f228ab8",
+    "content-hash": "6fff807338898dccaf8ffe4399006a88",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -75,17 +75,128 @@
             "time": "2017-07-22 12:18:28"
         },
         {
-            "name": "erusev/parsedown",
-            "version": "1.6.4",
+            "name": "doctrine/lexer",
+            "version": "v1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/erusev/parsedown.git",
-                "reference": "fbe3fe878f4fe69048bb8a52783a09802004f548"
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/erusev/parsedown/zipball/fbe3fe878f4fe69048bb8a52783a09802004f548",
-                "reference": "fbe3fe878f4fe69048bb8a52783a09802004f548",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Lexer\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "lexer",
+                "parser"
+            ],
+            "time": "2014-09-09 13:34:57"
+        },
+        {
+            "name": "egulias/email-validator",
+            "version": "2.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/egulias/EmailValidator.git",
+                "reference": "1bec00a10039b823cc94eef4eddd47dcd3b2ca04"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/1bec00a10039b823cc94eef4eddd47dcd3b2ca04",
+                "reference": "1bec00a10039b823cc94eef4eddd47dcd3b2ca04",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^1.0.1",
+                "php": ">= 5.5"
+            },
+            "require-dev": {
+                "dominicsayers/isemail": "dev-master",
+                "phpunit/phpunit": "^4.8.35",
+                "satooshi/php-coveralls": "^1.0.1"
+            },
+            "suggest": {
+                "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Egulias\\EmailValidator\\": "EmailValidator"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eduardo Gulias Davis"
+                }
+            ],
+            "description": "A library for validating emails against several RFCs",
+            "homepage": "https://github.com/egulias/EmailValidator",
+            "keywords": [
+                "email",
+                "emailvalidation",
+                "emailvalidator",
+                "validation",
+                "validator"
+            ],
+            "time": "2017-11-15 23:40:40"
+        },
+        {
+            "name": "erusev/parsedown",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/erusev/parsedown.git",
+                "reference": "6678d59be48c4be64eaca6ce70bea48a09488cc2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/erusev/parsedown/zipball/6678d59be48c4be64eaca6ce70bea48a09488cc2",
+                "reference": "6678d59be48c4be64eaca6ce70bea48a09488cc2",
                 "shasum": ""
             },
             "require": {
@@ -117,7 +228,7 @@
                 "markdown",
                 "parser"
             ],
-            "time": "2017-11-14 20:44:03"
+            "time": "2018-02-28 11:41:37"
         },
         {
             "name": "fzaninotto/faker",
@@ -215,37 +326,44 @@
         },
         {
             "name": "jgrossi/corcel",
-            "version": "v2.4.1",
+            "version": "v2.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/corcel/corcel.git",
-                "reference": "c351f11af7a24d697342d0027532c8cbd8dd7fd6"
+                "reference": "73bac867119a03526f7f64ff469fa5188c5df291"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/corcel/corcel/zipball/c351f11af7a24d697342d0027532c8cbd8dd7fd6",
-                "reference": "c351f11af7a24d697342d0027532c8cbd8dd7fd6",
+                "url": "https://api.github.com/repos/corcel/corcel/zipball/73bac867119a03526f7f64ff469fa5188c5df291",
+                "reference": "73bac867119a03526f7f64ff469fa5188c5df291",
                 "shasum": ""
             },
             "require": {
                 "fzaninotto/faker": "^1.6",
                 "hautelook/phpass": "0.3.4",
-                "illuminate/database": "~5.4.0",
-                "illuminate/filesystem": "~5.4.0",
-                "illuminate/support": "~5.4.0",
-                "php": ">=5.6.4",
+                "illuminate/database": "5.5.*",
+                "illuminate/filesystem": "5.5.*",
+                "illuminate/support": "5.5.*",
+                "php": ">=7.0.0",
                 "thunderer/shortcode": "^0.6.2"
             },
             "replace": {
                 "juniorgrossi/corcel": "self.version"
             },
             "require-dev": {
-                "orchestra/database": "~3.4.0",
-                "orchestra/testbench": "~3.4.0",
-                "phpunit/phpunit": "~4.8",
-                "satooshi/php-coveralls": "dev-master"
+                "codeclimate/php-test-reporter": "^0.4.4",
+                "orchestra/database": "3.5.*",
+                "orchestra/testbench": "3.5.*",
+                "phpunit/phpunit": "~6.0"
             },
             "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Corcel\\Laravel\\CorcelServiceProvider"
+                    ]
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Corcel\\": "src/",
@@ -265,43 +383,44 @@
             ],
             "description": "Use WordPress backend with Laravel or any PHP framework",
             "homepage": "http://github.com/corcel/corcel",
-            "time": "2017-08-19 17:47:24"
+            "time": "2018-02-20 19:57:43"
         },
         {
             "name": "laravel/framework",
-            "version": "v5.4.36",
+            "version": "v5.5.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "1062a22232071c3e8636487c86ec1ae75681bbf9"
+                "reference": "9283cea4a5727aaf1def60a8fa820e49df2cf874"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/1062a22232071c3e8636487c86ec1ae75681bbf9",
-                "reference": "1062a22232071c3e8636487c86ec1ae75681bbf9",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/9283cea4a5727aaf1def60a8fa820e49df2cf874",
+                "reference": "9283cea4a5727aaf1def60a8fa820e49df2cf874",
                 "shasum": ""
             },
             "require": {
                 "doctrine/inflector": "~1.1",
-                "erusev/parsedown": "~1.6",
+                "erusev/parsedown": "~1.7",
                 "ext-mbstring": "*",
                 "ext-openssl": "*",
                 "league/flysystem": "~1.0",
-                "monolog/monolog": "~1.11",
+                "monolog/monolog": "~1.12",
                 "mtdowling/cron-expression": "~1.0",
                 "nesbot/carbon": "~1.20",
-                "paragonie/random_compat": "~1.4|~2.0",
-                "php": ">=5.6.4",
+                "php": ">=7.0",
+                "psr/container": "~1.0",
+                "psr/simple-cache": "^1.0",
                 "ramsey/uuid": "~3.0",
-                "swiftmailer/swiftmailer": "~5.4",
-                "symfony/console": "~3.2",
-                "symfony/debug": "~3.2",
-                "symfony/finder": "~3.2",
-                "symfony/http-foundation": "~3.2",
-                "symfony/http-kernel": "~3.2",
-                "symfony/process": "~3.2",
-                "symfony/routing": "~3.2",
-                "symfony/var-dumper": "~3.2",
+                "swiftmailer/swiftmailer": "~6.0",
+                "symfony/console": "~3.3",
+                "symfony/debug": "~3.3",
+                "symfony/finder": "~3.3",
+                "symfony/http-foundation": "~3.3",
+                "symfony/http-kernel": "~3.3",
+                "symfony/process": "~3.3",
+                "symfony/routing": "~3.3",
+                "symfony/var-dumper": "~3.3",
                 "tijsverkoyen/css-to-inline-styles": "~2.2",
                 "vlucas/phpdotenv": "~2.2"
             },
@@ -318,7 +437,6 @@
                 "illuminate/database": "self.version",
                 "illuminate/encryption": "self.version",
                 "illuminate/events": "self.version",
-                "illuminate/exception": "self.version",
                 "illuminate/filesystem": "self.version",
                 "illuminate/hashing": "self.version",
                 "illuminate/http": "self.version",
@@ -335,38 +453,43 @@
                 "illuminate/translation": "self.version",
                 "illuminate/validation": "self.version",
                 "illuminate/view": "self.version",
-                "tightenco/collect": "self.version"
+                "tightenco/collect": "<5.5.33"
             },
             "require-dev": {
                 "aws/aws-sdk-php": "~3.0",
                 "doctrine/dbal": "~2.5",
-                "mockery/mockery": "~0.9.4",
+                "filp/whoops": "^2.1.4",
+                "mockery/mockery": "~1.0",
+                "orchestra/testbench-core": "3.5.*",
                 "pda/pheanstalk": "~3.0",
-                "phpunit/phpunit": "~5.7",
-                "predis/predis": "~1.0",
-                "symfony/css-selector": "~3.2",
-                "symfony/dom-crawler": "~3.2"
+                "phpunit/phpunit": "~6.0",
+                "predis/predis": "^1.1.1",
+                "symfony/css-selector": "~3.3",
+                "symfony/dom-crawler": "~3.3"
             },
             "suggest": {
                 "aws/aws-sdk-php": "Required to use the SQS queue driver and SES mail driver (~3.0).",
                 "doctrine/dbal": "Required to rename columns and drop SQLite columns (~2.5).",
+                "ext-pcntl": "Required to use all features of the queue worker.",
+                "ext-posix": "Required to use all features of the queue worker.",
                 "fzaninotto/faker": "Required to use the eloquent factory builder (~1.4).",
                 "guzzlehttp/guzzle": "Required to use the Mailgun and Mandrill mail drivers and the ping methods on schedules (~6.0).",
                 "laravel/tinker": "Required to use the tinker console command (~1.0).",
                 "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (~1.0).",
+                "league/flysystem-cached-adapter": "Required to use Flysystem caching (~1.0).",
                 "league/flysystem-rackspace": "Required to use the Flysystem Rackspace driver (~1.0).",
                 "nexmo/client": "Required to use the Nexmo transport (~1.0).",
                 "pda/pheanstalk": "Required to use the beanstalk queue driver (~3.0).",
                 "predis/predis": "Required to use the redis cache and queue drivers (~1.0).",
-                "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (~2.0).",
-                "symfony/css-selector": "Required to use some of the crawler integration testing tools (~3.2).",
-                "symfony/dom-crawler": "Required to use most of the crawler integration testing tools (~3.2).",
-                "symfony/psr-http-message-bridge": "Required to psr7 bridging features (0.2.*)."
+                "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (~3.0).",
+                "symfony/css-selector": "Required to use some of the crawler integration testing tools (~3.3).",
+                "symfony/dom-crawler": "Required to use most of the crawler integration testing tools (~3.3).",
+                "symfony/psr-http-message-bridge": "Required to psr7 bridging features (~1.0)."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.4-dev"
+                    "dev-master": "5.5-dev"
                 }
             },
             "autoload": {
@@ -394,20 +517,20 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2017-08-30 09:26:16"
+            "time": "2018-03-01 13:59:00"
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.42",
+            "version": "1.0.43",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "09eabc54e199950041aef258a85847676496fe8e"
+                "reference": "1ce7cc142d906ba58dc54c82915d355a9191c8a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/09eabc54e199950041aef258a85847676496fe8e",
-                "reference": "09eabc54e199950041aef258a85847676496fe8e",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/1ce7cc142d906ba58dc54c82915d355a9191c8a8",
+                "reference": "1ce7cc142d906ba58dc54c82915d355a9191c8a8",
                 "shasum": ""
             },
             "require": {
@@ -478,7 +601,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2018-01-27 16:03:56"
+            "time": "2018-03-01 10:27:04"
         },
         {
             "name": "monolog/monolog",
@@ -604,25 +727,25 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "1.22.1",
+            "version": "1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "7cdf42c0b1cc763ab7e4c33c47a24e27c66bfccc"
+                "reference": "4a874a39b2b00d7e0146cd46fab6f47c41ce9e65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/7cdf42c0b1cc763ab7e4c33c47a24e27c66bfccc",
-                "reference": "7cdf42c0b1cc763ab7e4c33c47a24e27c66bfccc",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/4a874a39b2b00d7e0146cd46fab6f47c41ce9e65",
+                "reference": "4a874a39b2b00d7e0146cd46fab6f47c41ce9e65",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0",
-                "symfony/translation": "~2.6 || ~3.0"
+                "symfony/translation": "~2.6 || ~3.0 || ~4.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "~2",
-                "phpunit/phpunit": "~4.0 || ~5.0"
+                "phpunit/phpunit": "^4.8.35 || ^5.7"
             },
             "type": "library",
             "extra": {
@@ -653,7 +776,7 @@
                 "datetime",
                 "time"
             ],
-            "time": "2017-01-16 07:55:07"
+            "time": "2018-02-28 09:22:05"
         },
         {
             "name": "paragonie/random_compat",
@@ -704,6 +827,55 @@
             "time": "2017-09-27 21:40:39"
         },
         {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14 16:28:37"
+        },
+        {
             "name": "psr/log",
             "version": "1.0.2",
             "source": {
@@ -749,6 +921,54 @@
                 "psr-3"
             ],
             "time": "2016-10-10 12:19:37"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "time": "2017-10-23 01:57:42"
         },
         {
             "name": "ramsey/uuid",
@@ -832,29 +1052,30 @@
         },
         {
             "name": "swiftmailer/swiftmailer",
-            "version": "v5.4.9",
+            "version": "v6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "7ffc1ea296ed14bf8260b6ef11b80208dbadba91"
+                "reference": "412333372fb6c8ffb65496a2bbd7321af75733fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/7ffc1ea296ed14bf8260b6ef11b80208dbadba91",
-                "reference": "7ffc1ea296ed14bf8260b6ef11b80208dbadba91",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/412333372fb6c8ffb65496a2bbd7321af75733fc",
+                "reference": "412333372fb6c8ffb65496a2bbd7321af75733fc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "egulias/email-validator": "~2.0",
+                "php": ">=7.0.0"
             },
             "require-dev": {
                 "mockery/mockery": "~0.9.1",
-                "symfony/phpunit-bridge": "~3.2"
+                "symfony/phpunit-bridge": "~3.3@dev"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.4-dev"
+                    "dev-master": "6.0-dev"
                 }
             },
             "autoload": {
@@ -876,26 +1097,26 @@
                 }
             ],
             "description": "Swiftmailer, free feature-rich PHP mailer",
-            "homepage": "https://swiftmailer.symfony.com",
+            "homepage": "http://swiftmailer.symfony.com",
             "keywords": [
                 "email",
                 "mail",
                 "mailer"
             ],
-            "time": "2018-01-23 07:37:21"
+            "time": "2017-09-30 22:39:41"
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.4",
+            "version": "v3.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "26b6f419edda16c19775211987651cb27baea7f1"
+                "reference": "067339e9b8ec30d5f19f5950208893ff026b94f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/26b6f419edda16c19775211987651cb27baea7f1",
-                "reference": "26b6f419edda16c19775211987651cb27baea7f1",
+                "url": "https://api.github.com/repos/symfony/console/zipball/067339e9b8ec30d5f19f5950208893ff026b94f7",
+                "reference": "067339e9b8ec30d5f19f5950208893ff026b94f7",
                 "shasum": ""
             },
             "require": {
@@ -951,20 +1172,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-29 09:03:43"
+            "time": "2018-02-26 15:46:28"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v3.4.4",
+            "version": "v3.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "e66394bc7610e69279bfdb3ab11b4fe65403f556"
+                "reference": "544655f1fc078a9cd839fdda2b7b1e64627c826a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/e66394bc7610e69279bfdb3ab11b4fe65403f556",
-                "reference": "e66394bc7610e69279bfdb3ab11b4fe65403f556",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/544655f1fc078a9cd839fdda2b7b1e64627c826a",
+                "reference": "544655f1fc078a9cd839fdda2b7b1e64627c826a",
                 "shasum": ""
             },
             "require": {
@@ -1004,20 +1225,20 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-03 07:37:34"
+            "time": "2018-02-03 14:55:07"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.4.4",
+            "version": "v3.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "53f6af2805daf52a43b393b93d2f24925d35c937"
+                "reference": "9b1071f86e79e1999b3d3675d2e0e7684268b9bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/53f6af2805daf52a43b393b93d2f24925d35c937",
-                "reference": "53f6af2805daf52a43b393b93d2f24925d35c937",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/9b1071f86e79e1999b3d3675d2e0e7684268b9bc",
+                "reference": "9b1071f86e79e1999b3d3675d2e0e7684268b9bc",
                 "shasum": ""
             },
             "require": {
@@ -1060,20 +1281,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-18 22:16:57"
+            "time": "2018-02-28 21:49:22"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.4.4",
+            "version": "v3.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "26b87b6bca8f8f797331a30b76fdae5342dc26ca"
+                "reference": "58990682ac3fdc1f563b7e705452921372aad11d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/26b87b6bca8f8f797331a30b76fdae5342dc26ca",
-                "reference": "26b87b6bca8f8f797331a30b76fdae5342dc26ca",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/58990682ac3fdc1f563b7e705452921372aad11d",
+                "reference": "58990682ac3fdc1f563b7e705452921372aad11d",
                 "shasum": ""
             },
             "require": {
@@ -1123,20 +1344,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-03 07:37:34"
+            "time": "2018-02-14 10:03:57"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.4",
+            "version": "v3.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "613e26310776f49a1773b6737c6bd554b8bc8c6f"
+                "reference": "6a615613745cef820d807443f32076bb9f5d0a38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/613e26310776f49a1773b6737c6bd554b8bc8c6f",
-                "reference": "613e26310776f49a1773b6737c6bd554b8bc8c6f",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/6a615613745cef820d807443f32076bb9f5d0a38",
+                "reference": "6a615613745cef820d807443f32076bb9f5d0a38",
                 "shasum": ""
             },
             "require": {
@@ -1172,20 +1393,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-03 07:37:34"
+            "time": "2018-02-11 17:15:12"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v3.4.4",
+            "version": "v3.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "8c39071ac9cc7e6d8dab1d556c990dc0d2cc3d30"
+                "reference": "6f5935723c11b4125fc9927db6ad2feaa196e175"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/8c39071ac9cc7e6d8dab1d556c990dc0d2cc3d30",
-                "reference": "8c39071ac9cc7e6d8dab1d556c990dc0d2cc3d30",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/6f5935723c11b4125fc9927db6ad2feaa196e175",
+                "reference": "6f5935723c11b4125fc9927db6ad2feaa196e175",
                 "shasum": ""
             },
             "require": {
@@ -1226,20 +1447,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-29 09:03:43"
+            "time": "2018-02-22 10:48:49"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v3.4.4",
+            "version": "v3.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "911d2e5dd4beb63caad9a72e43857de984301907"
+                "reference": "494f950becf513c174f52f9010cedb9026c12a92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/911d2e5dd4beb63caad9a72e43857de984301907",
-                "reference": "911d2e5dd4beb63caad9a72e43857de984301907",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/494f950becf513c174f52f9010cedb9026c12a92",
+                "reference": "494f950becf513c174f52f9010cedb9026c12a92",
                 "shasum": ""
             },
             "require": {
@@ -1251,7 +1472,7 @@
             },
             "conflict": {
                 "symfony/config": "<2.8",
-                "symfony/dependency-injection": "<3.4",
+                "symfony/dependency-injection": "<3.4.5|<4.0.5,>=4",
                 "symfony/var-dumper": "<3.3",
                 "twig/twig": "<1.34|<2.4,>=2"
             },
@@ -1265,7 +1486,7 @@
                 "symfony/config": "~2.8|~3.0|~4.0",
                 "symfony/console": "~2.8|~3.0|~4.0",
                 "symfony/css-selector": "~2.8|~3.0|~4.0",
-                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/dependency-injection": "^3.4.5|^4.0.5",
                 "symfony/dom-crawler": "~2.8|~3.0|~4.0",
                 "symfony/expression-language": "~2.8|~3.0|~4.0",
                 "symfony/finder": "~2.8|~3.0|~4.0",
@@ -1314,7 +1535,7 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-29 12:29:46"
+            "time": "2018-03-01 19:23:56"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1436,16 +1657,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v3.4.4",
+            "version": "v3.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "09a5172057be8fc677840e591b17f385e58c7c0d"
+                "reference": "cc4aea21f619116aaf1c58016a944e4821c8e8af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/09a5172057be8fc677840e591b17f385e58c7c0d",
-                "reference": "09a5172057be8fc677840e591b17f385e58c7c0d",
+                "url": "https://api.github.com/repos/symfony/process/zipball/cc4aea21f619116aaf1c58016a944e4821c8e8af",
+                "reference": "cc4aea21f619116aaf1c58016a944e4821c8e8af",
                 "shasum": ""
             },
             "require": {
@@ -1481,20 +1702,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-29 09:03:43"
+            "time": "2018-02-12 17:55:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v3.4.4",
+            "version": "v3.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "235d01730d553a97732990588407eaf6779bb4b2"
+                "reference": "8773a9d52715f1a579576ce0e60213de34f5ef3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/235d01730d553a97732990588407eaf6779bb4b2",
-                "reference": "235d01730d553a97732990588407eaf6779bb4b2",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/8773a9d52715f1a579576ce0e60213de34f5ef3e",
+                "reference": "8773a9d52715f1a579576ce0e60213de34f5ef3e",
                 "shasum": ""
             },
             "require": {
@@ -1559,20 +1780,20 @@
                 "uri",
                 "url"
             ],
-            "time": "2018-01-16 18:03:57"
+            "time": "2018-02-28 21:49:22"
         },
         {
             "name": "symfony/translation",
-            "version": "v3.4.4",
+            "version": "v3.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "10b32cf0eae28b9b39fe26c456c42b19854c4b84"
+                "reference": "80e19eaf12cbb546ac40384e5c55c36306823e57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/10b32cf0eae28b9b39fe26c456c42b19854c4b84",
-                "reference": "10b32cf0eae28b9b39fe26c456c42b19854c4b84",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/80e19eaf12cbb546ac40384e5c55c36306823e57",
+                "reference": "80e19eaf12cbb546ac40384e5c55c36306823e57",
                 "shasum": ""
             },
             "require": {
@@ -1627,20 +1848,20 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-18 22:16:57"
+            "time": "2018-02-22 06:28:18"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v3.4.4",
+            "version": "v3.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "472a9849930cf21f73abdb02240f17cf5b5bd1a7"
+                "reference": "80964679d81da3d5618519e0e4be488c3d7ecd7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/472a9849930cf21f73abdb02240f17cf5b5bd1a7",
-                "reference": "472a9849930cf21f73abdb02240f17cf5b5bd1a7",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/80964679d81da3d5618519e0e4be488c3d7ecd7d",
+                "reference": "80964679d81da3d5618519e0e4be488c3d7ecd7d",
                 "shasum": ""
             },
             "require": {
@@ -1696,7 +1917,7 @@
                 "debug",
                 "dump"
             ],
-            "time": "2018-01-29 09:03:43"
+            "time": "2018-02-22 17:29:24"
         },
         {
             "name": "thunderer/shortcode",
@@ -1950,27 +2171,27 @@
         },
         {
             "name": "orchestra/database",
-            "version": "v3.4.4",
+            "version": "v3.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/database.git",
-                "reference": "2bc4ab6e683398d8c98d28fb7f3e91887658834c"
+                "reference": "abcfcd827c0b1196cd200315390720e52a4a2a7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/database/zipball/2bc4ab6e683398d8c98d28fb7f3e91887658834c",
-                "reference": "2bc4ab6e683398d8c98d28fb7f3e91887658834c",
+                "url": "https://api.github.com/repos/orchestral/database/zipball/abcfcd827c0b1196cd200315390720e52a4a2a7b",
+                "reference": "abcfcd827c0b1196cd200315390720e52a4a2a7b",
                 "shasum": ""
             },
             "require": {
-                "illuminate/contracts": "~5.4.0",
-                "illuminate/database": "~5.4.17",
-                "php": ">=5.6.0"
+                "illuminate/contracts": "~5.5.0",
+                "illuminate/database": "~5.5.0",
+                "php": ">=7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "3.5-dev"
                 }
             },
             "autoload": {
@@ -2000,43 +2221,39 @@
                 "orchestra-platform",
                 "orchestral"
             ],
-            "time": "2017-08-25 10:03:18"
+            "time": "2017-11-03 02:33:29"
         },
         {
             "name": "orchestra/testbench",
-            "version": "v3.4.10",
+            "version": "v3.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench.git",
-                "reference": "3f4f3a129fa315d65f6827b3eeb89c4190e19d19"
+                "reference": "fd032489df469d611a264083e62db96677c9061e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench/zipball/3f4f3a129fa315d65f6827b3eeb89c4190e19d19",
-                "reference": "3f4f3a129fa315d65f6827b3eeb89c4190e19d19",
+                "url": "https://api.github.com/repos/orchestral/testbench/zipball/fd032489df469d611a264083e62db96677c9061e",
+                "reference": "fd032489df469d611a264083e62db96677c9061e",
                 "shasum": ""
             },
             "require": {
-                "fzaninotto/faker": "~1.4",
-                "laravel/framework": "~5.4.17",
-                "orchestra/testbench-core": "~3.4.4",
-                "php": ">=5.6.0"
+                "laravel/framework": "~5.5.34",
+                "orchestra/testbench-core": "~3.5.9",
+                "php": ">=7.0",
+                "phpunit/phpunit": "~6.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "orchestra/database": "~3.4.0",
-                "phpunit/phpunit": "~5.7"
+                "mockery/mockery": "~1.0",
+                "orchestra/database": "~3.5.0"
             },
             "suggest": {
-                "mockery/mockery": "Allow to use Mockery for testing (^0.9.4).",
-                "orchestra/database": "Allow to use --realpath migration for testing (~3.4).",
-                "orchestra/testbench-browser-kit": "Allow to use legacy BrowserKit for testing (~3.4).",
-                "phpunit/phpunit": "Allow to use PHPUnit for testing (~5.7)."
+                "orchestra/testbench-browser-kit": "Allow to use legacy BrowserKit for testing (~3.5)."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "3.5-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2060,37 +2277,38 @@
                 "orchestral",
                 "testing"
             ],
-            "time": "2017-10-08 07:55:54"
+            "time": "2018-02-20 05:30:39"
         },
         {
             "name": "orchestra/testbench-core",
-            "version": "v3.4.4",
+            "version": "v3.5.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench-core.git",
-                "reference": "3533c7477b077afa8fc069979e3afde72a806698"
+                "reference": "997a5dfade0cfb9c88d5e1f2bf4ff76900311333"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/3533c7477b077afa8fc069979e3afde72a806698",
-                "reference": "3533c7477b077afa8fc069979e3afde72a806698",
+                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/997a5dfade0cfb9c88d5e1f2bf4ff76900311333",
+                "reference": "997a5dfade0cfb9c88d5e1f2bf4ff76900311333",
                 "shasum": ""
             },
             "require": {
                 "fzaninotto/faker": "~1.4",
-                "php": ">=5.6.0"
+                "php": ">=7.0"
             },
             "require-dev": {
-                "laravel/framework": "~5.4.17",
-                "mockery/mockery": "^0.9.4",
-                "orchestra/database": "~3.4.0",
-                "phpunit/phpunit": "~5.7 || ~6.0"
+                "laravel/framework": "~5.5.0",
+                "mockery/mockery": "~1.0",
+                "orchestra/database": "~3.5.0",
+                "phpunit/phpunit": "~6.0"
             },
             "suggest": {
-                "laravel/framework": "Required for testing (~5.4.0).",
-                "mockery/mockery": "Allow to use Mockery for testing (^0.9.4).",
-                "orchestra/database": "Allow to use --realpath migration for testing (~3.4).",
-                "orchestra/testbench-browser-kit": "Allow to use legacy BrowserKit for testing (~3.4).",
+                "laravel/framework": "Required for testing (~5.5.0).",
+                "mockery/mockery": "Allow to use Mockery for testing (~1.0).",
+                "orchestra/database": "Allow to use --realpath migration for testing (~3.5).",
+                "orchestra/testbench-browser-kit": "Allow to use legacy BrowserKit for testing (~3.5).",
+                "orchestra/testbench-dusk": "Allow to use Laravel Dusk for testing (~3.5).",
                 "phpunit/phpunit": "Allow to use PHPUnit for testing (~6.0)."
             },
             "type": "library",
@@ -2125,7 +2343,7 @@
                 "orchestral",
                 "testing"
             ],
-            "time": "2017-10-08 07:39:49"
+            "time": "2018-02-20 04:07:40"
         },
         {
             "name": "phar-io/manifest",
@@ -2383,16 +2601,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.4",
+            "version": "1.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "9f901e29c93dae4aa77c0bb161df4276f9c9a1be"
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/9f901e29c93dae4aa77c0bb161df4276f9c9a1be",
-                "reference": "9f901e29c93dae4aa77c0bb161df4276f9c9a1be",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
                 "shasum": ""
             },
             "require": {
@@ -2442,7 +2660,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-02-11 18:49:29"
+            "time": "2018-02-19 10:16:54"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2695,16 +2913,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.6",
+            "version": "6.5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3330ef26ade05359d006041316ed0fa9e8e3cefe"
+                "reference": "6bd77b57707c236833d2b57b968e403df060c9d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3330ef26ade05359d006041316ed0fa9e8e3cefe",
-                "reference": "3330ef26ade05359d006041316ed0fa9e8e3cefe",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6bd77b57707c236833d2b57b968e403df060c9d9",
+                "reference": "6bd77b57707c236833d2b57b968e403df060c9d9",
                 "shasum": ""
             },
             "require": {
@@ -2775,7 +2993,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-02-01 05:57:37"
+            "time": "2018-02-26 07:01:09"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -3492,7 +3710,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.5.9"
+        "php": ">=7.0.0"
     },
     "platform-dev": []
 }

--- a/src/Exception/MissingFieldException.php
+++ b/src/Exception/MissingFieldException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Corcel\Acf\Exception;
+
+/**
+ * Class MissingFieldException.
+ */
+class MissingFieldException extends \Exception
+{
+}

--- a/src/Field/BasicField.php
+++ b/src/Field/BasicField.php
@@ -93,8 +93,8 @@ abstract class BasicField
             trigger_error('Can not get an acf field for an unknown field name.');
         }
         if (!$this->acfField) {
-            $acfFieldName = $this->repository->getAcfFieldName($this->fieldName);
-            $this->acfField = AcfField::where('post_name', $acfFieldName)->first();
+            $fieldKey = $this->repository->getFieldKey($this->fieldName);
+            $this->acfField = AcfField::where('post_name', $fieldKey)->first();
         }
         return $this->acfField;
     }

--- a/src/Field/BasicField.php
+++ b/src/Field/BasicField.php
@@ -10,6 +10,7 @@ use Corcel\Model\Meta\TermMeta;
 use Corcel\Model\User;
 use Corcel\Model\Meta\UserMeta;
 use Corcel\Acf\Repositories\Repository;
+use Corcel\Acf\Repositories\PostRepository;
 
 /**
  * Class BasicField.
@@ -28,8 +29,13 @@ abstract class BasicField
      *
      * @param Repository $repository
      */
-    public function __construct(Repository $repository)
+    public function __construct($repository)
     {
+        // FIXME do we need the backwards-compatibility?
+        if ($repository instanceof Model) {
+            // trigger_error('Deprecated: fields should be instantiated with a repository.', E_USER_NOTICE);
+            $repository = new PostRepository($repository);
+        }
         $this->repository = $repository;
     }
 

--- a/src/Field/BasicField.php
+++ b/src/Field/BasicField.php
@@ -11,6 +11,7 @@ use Corcel\Model\User;
 use Corcel\Model\Meta\UserMeta;
 use Corcel\Acf\Repositories\Repository;
 use Corcel\Acf\Repositories\PostRepository;
+use Corcel\Acf\Models\AcfField;
 
 /**
  * Class BasicField.
@@ -23,6 +24,16 @@ abstract class BasicField
      * @var Repository
      */
     protected $repository;
+
+    /**
+     * @var string
+     */
+    protected $fieldName;
+
+    /**
+     * @var AcfField
+     */
+    protected $acfField;
 
     /**
      * Constructor method.
@@ -53,5 +64,38 @@ abstract class BasicField
     public function __toString()
     {
         return $this->get();
+    }
+
+    /**
+     * Process the field's content, e.g. get it from the db through the repository
+     */
+    public function process(string $fieldName)
+    {
+        $this->fieldName = $fieldName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFieldName()
+    {
+        return $this->fieldName;
+    }
+
+    /**
+     * Get the related acf field
+     *
+     * @return AcfField
+     */
+    public function getAcfField()
+    {
+        if (!$this->fieldName) {
+            trigger_error('Can not get an acf field for an unknown field name.');
+        }
+        if (!$this->acfField) {
+            $acfFieldName = $this->repository->getAcfFieldName($this->fieldName);
+            $this->acfField = AcfField::where('post_name', $acfFieldName)->first();
+        }
+        return $this->acfField;
     }
 }

--- a/src/Field/BasicField.php
+++ b/src/Field/BasicField.php
@@ -48,30 +48,6 @@ abstract class BasicField
     }
 
     /**
-     * @deprecated in favor of $this->repository->fetchValue()
-     */
-    public function fetchFieldKey($fieldName)
-    {
-        return $this->repository->fetchFieldKey($fieldName);
-    }
-
-    /**
-     * @deprecated in favor of $this->repository->fetchValue()
-     */
-    public function fetchFieldType($fieldKey)
-    {
-        return $this->repository->fetchFieldType($fieldKey);
-    }
-
-    /**
-     * @deprecated in favor of $this->repository->fetchValue()
-     */
-    public function getKeyName()
-    {
-        return $this->repository->getKeyName();
-    }
-
-    /**
      * @return mixed
      */
     public function __toString()

--- a/src/Field/BasicField.php
+++ b/src/Field/BasicField.php
@@ -9,6 +9,7 @@ use Corcel\Model\Term;
 use Corcel\Model\Meta\TermMeta;
 use Corcel\Model\User;
 use Corcel\Model\Meta\UserMeta;
+use Corcel\Acf\Repositories\Repository;
 
 /**
  * Class BasicField.
@@ -18,148 +19,51 @@ use Corcel\Model\Meta\UserMeta;
 abstract class BasicField
 {
     /**
-     * @var Model
+     * @var Repository
      */
-    protected $post;
-
-    /**
-     * @var PostMeta
-     */
-    protected $postMeta;
-
-    /**
-     * @var string
-     */
-    protected $name;
-
-    /**
-     * @var string
-     */
-    protected $key;
-
-    /**
-     * @var string
-     */
-    protected $type;
-
-    /**
-     * @var mixed
-     */
-    protected $value;
-
-    /**
-     * @var string
-     */
-    protected $connection;
+    protected $repository;
 
     /**
      * Constructor method.
      *
-     * @param Post $post
+     * @param Repository $repository
      */
-    public function __construct(Model $post)
+    public function __construct(Repository $repository)
     {
-        $this->post = $post;
-
-        if ($post instanceof Post) {
-            $this->postMeta = new PostMeta();
-        } elseif ($post instanceof Term) {
-            $this->postMeta = new TermMeta();
-        } elseif ($post instanceof User) {
-            $this->postMeta = new UserMeta();
-        }
-
-        $this->postMeta->setConnection($post->getConnectionName());
+        $this->repository = $repository;
     }
 
     /**
-     * Get the value of a field according it's post ID.
-     *
-     * @param string $field
-     *
-     * @return array|string
+     * @deprecated in favor of $this->repository->fetchValue()
      */
     public function fetchValue($field)
     {
-        $postMeta = $this->postMeta->where(
-           $this->getKeyName(), $this->post->getKey()
-        )->where('meta_key', $field)->first();
-
-        if (isset($postMeta->meta_value) and ! is_null($postMeta->meta_value)) {
-            $value = $postMeta->meta_value;
-            if ($array = @unserialize($value) and is_array($array)) {
-                $this->value = $array;
-
-                return $array;
-            } else {
-                $this->value = $value;
-
-                return $value;
-            }
-        }
+        return $this->repository->fetchValue($field);
     }
 
     /**
-     * @param string $fieldName
-     *
-     * @return string
+     * @deprecated in favor of $this->repository->fetchValue()
      */
     public function fetchFieldKey($fieldName)
     {
-        $this->name = $fieldName;
-
-        $postMeta = $this->postMeta->where($this->getKeyName(), $this->post->getKey())
-            ->where('meta_key', '_' . $fieldName)
-            ->first();
-
-        if (!$postMeta) {
-            return null;
-        }
-
-        $this->key = $postMeta->meta_value;
-
-        return $this->key;
+        return $this->repository->fetchFieldKey($fieldName);
     }
 
     /**
-     * @param string $fieldKey
-     *
-     * @return string|null
+     * @deprecated in favor of $this->repository->fetchValue()
      */
     public function fetchFieldType($fieldKey)
     {
-        $post = Post::on($this->post->getConnectionName())
-                   ->orWhere(function ($query) use ($fieldKey) {
-                       $query->where('post_name', $fieldKey);
-                       $query->where('post_type', 'acf-field');
-                   })->first();
-
-        if ($post) {
-            $fieldData = unserialize($post->post_content);
-            $this->type = isset($fieldData['type']) ? $fieldData['type'] : 'text';
-
-            return $this->type;
-        }
-
-        return null;
+        return $this->repository->fetchFieldType($fieldKey);
     }
 
     /**
-     * Get the name of the key for the field.
-     *
-     * @return string
+     * @deprecated in favor of $this->repository->fetchValue()
      */
     public function getKeyName()
     {
-        if ($this->post instanceof Post) {
-            return 'post_id';
-        } elseif ($this->post instanceof Term) {
-            return 'term_id';
-        } elseif ($this->post instanceof User) {
-            return 'user_id';
-        }
+        return $this->repository->getKeyName();
     }
-
 
     /**
      * @return mixed

--- a/src/Field/CloneField.php
+++ b/src/Field/CloneField.php
@@ -34,8 +34,8 @@ class CloneField extends BasicField implements FieldInterface
         $acfField = AcfField::where('post_name', $search)->first();
 
         if (!$acfField) {
-            // dd($this->fieldName);
-            trigger_error('Could not find acf field for ' . $search . ' / ' . $fieldKey . ' / ' . $field);
+            // this happens when the post has not been saved yet 
+            return null;
         }
 
         $this->originalField = FieldFactory::makeField($field, $this->repository, $acfField->type);
@@ -46,6 +46,9 @@ class CloneField extends BasicField implements FieldInterface
      */
     public function get()
     {
+        if (!$this->originalField) {
+            return null;
+        }
         return $this->originalField->get();
     }
 }

--- a/src/Field/CloneField.php
+++ b/src/Field/CloneField.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Corcel\Acf\Field;
+
+use Corcel\Acf\FieldInterface;
+use Corcel\Acf\Models\AcfField;
+use Corcel\Acf\FieldFactory;
+
+/**
+ * Class CloneField. Only supports cloning __one__ field, not groups. If you
+ * need to clone a group of fields, consider putting all of them into a repeater
+ * with min = 1 & max = 1 and clone that repeater field
+ */
+class CloneField extends BasicField implements FieldInterface
+{
+    /**
+     * Holds the cloned field
+     * 
+     * @var FieldInterface
+     */
+    protected $originalField;
+
+    /**
+     * @param string $field
+     */
+    public function process(string $field)
+    {
+        parent::process($field);
+
+        $fieldKey = $this->repository->getFieldKey($field);
+
+        $search = substr($fieldKey, strrpos($fieldKey, 'field_'));
+
+        $acfField = AcfField::where('post_name', $search)->first();
+
+        if (!$acfField) {
+            // dd($this->fieldName);
+            trigger_error('Could not find acf field for ' . $search . ' / ' . $fieldKey . ' / ' . $field);
+        }
+
+        $this->originalField = FieldFactory::makeField($field, $this->repository, $acfField->type);
+    }
+
+    /**
+     * @return string
+     */
+    public function get()
+    {
+        return $this->originalField->get();
+    }
+}

--- a/src/Field/DateTime.php
+++ b/src/Field/DateTime.php
@@ -21,8 +21,9 @@ class DateTime extends BasicField implements FieldInterface
     /**
      * @param string $fieldName
      */
-    public function process($fieldName)
+    public function process(string $fieldName)
     {
+        parent::process($fieldName);
         $dateString = $this->fetchValue($fieldName);
         $format = $this->getDateFormatFromString($dateString);
         $this->date = Carbon::createFromFormat($format, $dateString);

--- a/src/Field/File.php
+++ b/src/Field/File.php
@@ -50,8 +50,9 @@ class File extends BasicField implements FieldInterface
     /**
      * @param string $field
      */
-    public function process($field)
+    public function process(string $field)
     {
+        parent::process($field);
         $value = $this->fetchValue($field);
 
         $connection = $this->repository->getConnectionName();

--- a/src/Field/File.php
+++ b/src/Field/File.php
@@ -54,7 +54,7 @@ class File extends BasicField implements FieldInterface
     {
         $value = $this->fetchValue($field);
 
-        $connection = $this->post->getConnectionName();
+        $connection = $this->repository->getConnectionName();
 
         if ($file = Post::on($connection)->find(intval($value))) {
             $this->fillFields($file);

--- a/src/Field/FlexibleContent.php
+++ b/src/Field/FlexibleContent.php
@@ -27,8 +27,7 @@ class FlexibleContent extends BasicField implements FieldInterface
     {
         $this->name = $fieldName;
 
-        $builder = $this->fetchPostsMeta($fieldName, $this->post);
-        $fields = $this->fetchFields($fieldName, $builder);
+        $fields = $this->repository->flexibleContentFetchFields($this);
 
         $this->fields = new Collection($fields);
     }
@@ -39,81 +38,5 @@ class FlexibleContent extends BasicField implements FieldInterface
     public function get()
     {
         return $this->fields;
-    }
-
-    /**
-     * @param string $metaKey
-     * @param string $fieldName
-     *
-     * @return int
-     */
-    protected function retrieveIdFromFieldName($metaKey, $fieldName)
-    {
-        return (int) str_replace("{$fieldName}_", '', $metaKey);
-    }
-
-    /**
-     * @param string $metaKey
-     * @param string $fieldName
-     * @param int    $id
-     *
-     * @return string
-     */
-    protected function retrieveFieldName($metaKey, $fieldName, $id)
-    {
-        $pattern = "{$fieldName}_{$id}_";
-
-        return str_replace($pattern, '', $metaKey);
-    }
-
-    /**
-     * @param $fieldName
-     * @param Post $post
-     *
-     * @return mixed
-     */
-    protected function fetchPostsMeta($fieldName, Model $post)
-    {
-        $builder = $this->postMeta->where($this->getKeyName(), $this->post->getKey());
-        $builder->where('meta_key', 'like', "{$fieldName}_%");
-
-        return $builder;
-    }
-
-    /**
-     * @param $fieldName
-     * @param $builder
-     *
-     * @return mixed
-     */
-    protected function fetchFields($fieldName, Builder $builder)
-    {
-        $fields = [];
-        $blocks  = $this->fetchValue($fieldName, $this->post);
-
-        foreach ($builder->get() as $meta) {
-            $id = $this->retrieveIdFromFieldName($meta->meta_key, $fieldName);
-
-            $name = $this->retrieveFieldName($meta->meta_key, $fieldName, $id);
-
-            $post = $this->post->ID != $meta->post_id ? $this->post->find($meta->post_id) : $this->post;
-            $field = FieldFactory::make($meta->meta_key, $post);
-
-            if ($field === null || !array_key_exists($id, $blocks)) {
-                continue;
-            }
-
-            if (empty($fields[$id])) {
-                $fields[$id] = new \stdClass;
-                $fields[$id]->type = $blocks[$id];
-                $fields[$id]->fields =  new \stdClass;
-            }
-
-            $fields[$id]->fields->$name = $field->get();
-        }
-
-        ksort($fields);
-
-        return $fields;
     }
 }

--- a/src/Field/FlexibleContent.php
+++ b/src/Field/FlexibleContent.php
@@ -23,9 +23,9 @@ class FlexibleContent extends BasicField implements FieldInterface
     /**
      * @param string $fieldName
      */
-    public function process($fieldName)
+    public function process(string $fieldName)
     {
-        $this->name = $fieldName;
+        parent::process($fieldName);
 
         $fields = $this->repository->flexibleContentFetchFields($this);
 

--- a/src/Field/Gallery.php
+++ b/src/Field/Gallery.php
@@ -36,7 +36,7 @@ class Gallery extends Image implements FieldInterface
 
             foreach ($attachments as $attachment) {
                 if (array_key_exists($attachment->ID, $metaDataValues)) {
-                    $image = new Image($this->post);
+                    $image = new Image($this->repository);
                     $image->fillFields($attachment);
                     $image->fillMetadataFields($metaDataValues[$attachment->ID]);
                     $this->images[] = $image;

--- a/src/Field/Gallery.php
+++ b/src/Field/Gallery.php
@@ -26,8 +26,9 @@ class Gallery extends Image implements FieldInterface
     /**
      * @param $field
      */
-    public function process($field)
+    public function process(string $field)
     {
+        parent::process($field);
         $value = $this->fetchValue($field);
         $ids = is_array($value) ? $value : @unserialize($value);
 

--- a/src/Field/Gallery.php
+++ b/src/Field/Gallery.php
@@ -28,7 +28,10 @@ class Gallery extends Image implements FieldInterface
      */
     public function process($field)
     {
-        if ($ids = $this->fetchValue($field)) {
+        $value = $this->fetchValue($field);
+        $ids = is_array($value) ? $value : @unserialize($value);
+
+        if ($ids) {
             $connection = $this->repository->getConnectionName();
             $attachments = Post::on($connection)->whereIn('ID', $ids)->get();
 

--- a/src/Field/Gallery.php
+++ b/src/Field/Gallery.php
@@ -29,7 +29,7 @@ class Gallery extends Image implements FieldInterface
     public function process($field)
     {
         if ($ids = $this->fetchValue($field)) {
-            $connection = $this->post->getConnectionName();
+            $connection = $this->repository->getConnectionName();
             $attachments = Post::on($connection)->whereIn('ID', $ids)->get();
 
             $metaDataValues = $this->fetchMultipleMetadataValues($attachments);

--- a/src/Field/Image.php
+++ b/src/Field/Image.php
@@ -61,7 +61,7 @@ class Image extends BasicField implements FieldInterface
     {
         $attachmentId = $this->fetchValue($field);
 
-        $connection = $this->post->getConnectionName();
+        $connection = $this->repository->getPost()->getConnectionName();
 
         if ($attachment = Post::on($connection)->find(intval($attachmentId))) {
             $this->fillFields($attachment);
@@ -114,7 +114,7 @@ class Image extends BasicField implements FieldInterface
      */
     protected function fillThumbnailFields(array $data)
     {
-        $size = new static($this->post);
+        $size = new static($this->repository->getPost());
         $size->filename = $data['file'];
         $size->width = $data['width'];
         $size->height = $data['height'];

--- a/src/Field/Image.php
+++ b/src/Field/Image.php
@@ -120,7 +120,7 @@ class Image extends BasicField implements FieldInterface
      */
     protected function fillThumbnailFields(array $data)
     {
-        $size = new static($this->repository->getPost($this->name));
+        $size = new Image($this->repository);
         $size->filename = $data['file'];
         $size->width = $data['width'];
         $size->height = $data['height'];

--- a/src/Field/Image.php
+++ b/src/Field/Image.php
@@ -54,11 +54,17 @@ class Image extends BasicField implements FieldInterface
      */
     protected $loadFromPost = false;
 
+    /*
+     * @var string
+     */
+    protected $name;
+
     /**
      * @param string $field
      */
     public function process($field)
     {
+        $this->name = $field;
         $attachmentId = $this->fetchValue($field);
 
         $connection = $this->repository->getConnectionName();
@@ -114,7 +120,7 @@ class Image extends BasicField implements FieldInterface
      */
     protected function fillThumbnailFields(array $data)
     {
-        $size = new static($this->repository->getPost());
+        $size = new static($this->repository->getPost($this->name));
         $size->filename = $data['file'];
         $size->width = $data['width'];
         $size->height = $data['height'];

--- a/src/Field/Image.php
+++ b/src/Field/Image.php
@@ -61,7 +61,7 @@ class Image extends BasicField implements FieldInterface
     {
         $attachmentId = $this->fetchValue($field);
 
-        $connection = $this->repository->getPost()->getConnectionName();
+        $connection = $this->repository->getConnectionName();
 
         if ($attachment = Post::on($connection)->find(intval($attachmentId))) {
             $this->fillFields($attachment);

--- a/src/Field/Image.php
+++ b/src/Field/Image.php
@@ -134,11 +134,7 @@ class Image extends BasicField implements FieldInterface
      */
     protected function fetchMetadataValue(Post $attachment)
     {
-        $meta = PostMeta::where('post_id', $attachment->ID)
-                        ->where('meta_key', '_wp_attachment_metadata')
-                        ->first();
-
-        return unserialize($meta->meta_value);
+        return unserialize($attachment->getMeta('_wp_attachment_metadata'));
     }
 
     /**

--- a/src/Field/Image.php
+++ b/src/Field/Image.php
@@ -54,17 +54,12 @@ class Image extends BasicField implements FieldInterface
      */
     protected $loadFromPost = false;
 
-    /*
-     * @var string
-     */
-    protected $name;
-
     /**
      * @param string $field
      */
-    public function process($field)
+    public function process(string $field)
     {
-        $this->name = $field;
+        parent::process($field);
         $attachmentId = $this->fetchValue($field);
 
         $connection = $this->repository->getConnectionName();

--- a/src/Field/PostObject.php
+++ b/src/Field/PostObject.php
@@ -20,8 +20,9 @@ class PostObject extends BasicField implements FieldInterface
     /**
      * @param string $fieldName
      */
-    public function process($fieldName)
+    public function process(string $fieldName)
     {
+        parent::process($fieldName);
         $postId = $this->fetchValue($fieldName);
         $connection = $this->repository->getConnectionName();
         

--- a/src/Field/PostObject.php
+++ b/src/Field/PostObject.php
@@ -25,6 +25,10 @@ class PostObject extends BasicField implements FieldInterface
         $postId = $this->fetchValue($fieldName);
         $connection = $this->repository->getConnectionName();
         
+        if ($unserialized = @unserialize($postId)) {
+            $postId = $unserialized;
+        }
+
         if (is_array($postId)) {
             $this->object = Post::on($connection)->whereIn('ID', $postId)->get()->sortBy(function ($item) use ($postId) {
                 return array_search($item->getKey(), $postId);

--- a/src/Field/PostObject.php
+++ b/src/Field/PostObject.php
@@ -23,7 +23,7 @@ class PostObject extends BasicField implements FieldInterface
     public function process($fieldName)
     {
         $postId = $this->fetchValue($fieldName);
-        $connection = $this->post->getConnectionName();
+        $connection = $this->repository->getConnectionName();
         
         if (is_array($postId)) {
             $this->object = Post::on($connection)->whereIn('ID', $postId)->get()->sortBy(function ($item) use ($postId) {

--- a/src/Field/Repeater.php
+++ b/src/Field/Repeater.php
@@ -39,29 +39,4 @@ class Repeater extends BasicField implements FieldInterface
     {
         return $this->fields;
     }
-
-    /**
-     * @param string $metaKey
-     * @param string $fieldName
-     *
-     * @return int
-     */
-    public function retrieveIdFromFieldName($metaKey, $fieldName)
-    {
-        return (int) str_replace("{$fieldName}_", '', $metaKey);
-    }
-
-    /**
-     * @param string $metaKey
-     * @param string $fieldName
-     * @param int    $id
-     *
-     * @return string
-     */
-    public function retrieveFieldName($metaKey, $fieldName, $id)
-    {
-        $pattern = "{$fieldName}_{$id}_";
-
-        return str_replace($pattern, '', $metaKey);
-    }
 }

--- a/src/Field/Repeater.php
+++ b/src/Field/Repeater.php
@@ -23,8 +23,9 @@ class Repeater extends BasicField implements FieldInterface
     /**
      * @param string $fieldName
      */
-    public function process($fieldName)
+    public function process(string $fieldName)
     {
+        parent::process($fieldName);
         $this->name = $fieldName;
 
         $fields = $this->repository->repeaterFetchFields($this);

--- a/src/Field/Term.php
+++ b/src/Field/Term.php
@@ -36,8 +36,9 @@ class Term extends BasicField implements FieldInterface
     /**
      * @param string $fieldName
      */
-    public function process($fieldName)
+    public function process(string $fieldName)
     {
+        parent::process($fieldName);
         $value = $this->fetchValue($fieldName);
 
         if ($unserialized = @unserialize($value)) {

--- a/src/Field/Term.php
+++ b/src/Field/Term.php
@@ -26,11 +26,11 @@ class Term extends BasicField implements FieldInterface
     /**
      * @param Post $post
      */
-    public function __construct(Post $post)
+    public function __construct($repository)
     {
-        parent::__construct($post);
+        parent::__construct($repository);
         $this->term = new \Corcel\Model\Term();
-        $this->term->setConnection($post->getConnectionName());
+        $this->term->setConnection($repository->getConnectionName());
     }
 
     /**
@@ -39,6 +39,11 @@ class Term extends BasicField implements FieldInterface
     public function process($fieldName)
     {
         $value = $this->fetchValue($fieldName);
+
+        if ($unserialized = @unserialize($value)) {
+            $value = $unserialized;
+        }
+
         if (is_array($value)) {
             $this->items = $this->term->whereIn('term_id', $value)->get(); // ids
         } else {

--- a/src/Field/Text.php
+++ b/src/Field/Text.php
@@ -20,8 +20,9 @@ class Text extends BasicField implements FieldInterface
     /**
      * @param string $field
      */
-    public function process($field)
+    public function process(string $field)
     {
+        parent::process($field);
         $this->value = $this->fetchValue($field);
     }
 

--- a/src/Field/User.php
+++ b/src/Field/User.php
@@ -35,8 +35,9 @@ class User extends BasicField implements FieldInterface
     /**
      * @param string $fieldName
      */
-    public function process($fieldName)
+    public function process(string $fieldName)
     {
+        parent::process($fieldName);
         $userId = $this->fetchValue($fieldName);
         $this->value = $this->user->find($userId);
     }

--- a/src/Field/User.php
+++ b/src/Field/User.php
@@ -25,11 +25,11 @@ class User extends BasicField implements FieldInterface
     /**
      * @param Post $post
      */
-    public function __construct(Post $post)
+    public function __construct($post)
     {
         parent::__construct($post);
         $this->user = new \Corcel\Model\User();
-        $this->user->setConnection($post->getConnectionName());
+        $this->user->setConnection($this->repository->getConnectionName());
     }
 
     /**

--- a/src/FieldFactory.php
+++ b/src/FieldFactory.php
@@ -35,7 +35,7 @@ class FieldFactory
 
     /**
      * Instantiate a "regular" field based on a post object
-     * 
+     *
      * @param string $name
      * @param Post $post
      * @param null|string $type
@@ -60,7 +60,7 @@ class FieldFactory
 
     /**
      * Instantiate a field based on an acf option page
-     * 
+     *
      * @param string $name
      * @param OptionPage $optionPage
      * @param string $type cannot be null, because we cannot guess the type for fields inside repeater fields, as we would need the parent field name

--- a/src/FieldFactory.php
+++ b/src/FieldFactory.php
@@ -15,6 +15,7 @@ use Corcel\Acf\Field\Select;
 use Corcel\Acf\Field\Term;
 use Corcel\Acf\Field\Text;
 use Corcel\Acf\Field\User;
+use Corcel\Acf\Field\CloneField;
 use Corcel\Model;
 use Illuminate\Support\Collection;
 use Corcel\Acf\Repositories\Repository;
@@ -140,6 +141,9 @@ class FieldFactory
                 break;
             case 'flexible_content':
                 $field = new FlexibleContent($repository);
+                break;
+            case 'clone':
+                $field = new CloneField($repository);
                 break;
             default: return null;
         }

--- a/src/FieldFactory.php
+++ b/src/FieldFactory.php
@@ -17,6 +17,7 @@ use Corcel\Acf\Field\Text;
 use Corcel\Acf\Field\User;
 use Corcel\Model;
 use Illuminate\Support\Collection;
+use Corcel\Acf\Repositories\PostRepository;
 
 /**
  * Class FieldFactory.
@@ -38,8 +39,10 @@ class FieldFactory
      */
     public static function make($name, Model $post, $type = null)
     {
+        $repository = new PostRepository($post);
+
         if (null === $type) {
-            $fakeText = new Text($post);
+            $fakeText = new Text($repository);
             $key = $fakeText->fetchFieldKey($name);
 
             if ($key === null) { // Field does not exist
@@ -66,47 +69,47 @@ class FieldFactory
             case 'select':
             case 'checkbox':
             case 'radio':
-                $field = new Text($post);
+                $field = new Text($repository);
                 break;
             case 'image':
             case 'img':
-                $field = new Image($post);
+                $field = new Image($repository);
                 break;
             case 'file':
-                $field = new File($post);
+                $field = new File($repository);
                 break;
             case 'gallery':
-                $field = new Gallery($post);
+                $field = new Gallery($repository);
                 break;
             case 'true_false':
             case 'boolean':
-                $field = new Boolean($post);
+                $field = new Boolean($repository);
                 break;
             case 'post_object':
             case 'post':
             case 'relationship':
-                $field = new PostObject($post);
+                $field = new PostObject($repository);
                 break;
             case 'page_link':
-                $field = new PageLink($post);
+                $field = new PageLink($repository);
                 break;
             case 'taxonomy':
             case 'term':
-                $field = new Term($post);
+                $field = new Term($repository);
                 break;
             case 'user':
-                $field = new User($post);
+                $field = new User($repository);
                 break;
             case 'date_picker':
             case 'date_time_picker':
             case 'time_picker':
-                $field = new DateTime($post);
+                $field = new DateTime($repository);
                 break;
             case 'repeater':
-                $field = new Repeater($post);
+                $field = new Repeater($repository);
                 break;
             case 'flexible_content':
-                $field = new FlexibleContent($post);
+                $field = new FlexibleContent($repository);
                 break;
             default: return null;
         }

--- a/src/FieldInterface.php
+++ b/src/FieldInterface.php
@@ -14,7 +14,7 @@ interface FieldInterface
     /**
      * @param string $fieldName
      */
-    public function process($fieldName);
+    public function process(string $fieldName);
 
     /**
      * @return mixed

--- a/src/Models/AcfField.php
+++ b/src/Models/AcfField.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Corcel\Acf\Models;
+
+use Corcel\Model\Post;
+
+class AcfField extends Post
+{
+    /**
+     * @var string
+     */
+    protected $postType = 'acf-field';
+
+    public function getTypeAttribute()
+    {
+        $fieldData = unserialize($this->post_content);
+        return isset($fieldData['type']) ? $fieldData['type'] : 'text';
+    }
+}

--- a/src/Models/AcfField.php
+++ b/src/Models/AcfField.php
@@ -11,9 +11,14 @@ class AcfField extends Post
      */
     protected $postType = 'acf-field';
 
+    public function getContentAttribute()
+    {
+        return unserialize($this->post_content);
+    }
+
     public function getTypeAttribute()
     {
-        $fieldData = unserialize($this->post_content);
+        $fieldData = $this->content;
         return isset($fieldData['type']) ? $fieldData['type'] : 'text';
     }
 }

--- a/src/Models/AcfField.php
+++ b/src/Models/AcfField.php
@@ -21,4 +21,13 @@ class AcfField extends Post
         $fieldData = $this->content;
         return isset($fieldData['type']) ? $fieldData['type'] : 'text';
     }
+
+    /**
+     * Children of an acf field are acf fields themselves. Override parent
+     * method to get the correct class type
+     */
+    public function children()
+    {
+        return $this->hasMany(AcfField::class, 'post_parent');
+    }
 }

--- a/src/Models/AcfFieldGroup.php
+++ b/src/Models/AcfFieldGroup.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Corcel\Acf\Models;
+
+use Corcel\Model\Post;
+
+class AcfFieldGroup extends Post
+{
+    /**
+     * @var string
+     */
+    protected $postType = 'acf-field-group';
+}

--- a/src/OptionPage.php
+++ b/src/OptionPage.php
@@ -71,4 +71,9 @@ class OptionPage extends Model
 
         return $field ? $field->get() : null;
     }
+
+    public function getAcfField($fieldName)
+    {
+        return $this->page->children->where('post_excerpt', $fieldName)->first();
+    }
 }

--- a/src/OptionPage.php
+++ b/src/OptionPage.php
@@ -6,11 +6,18 @@ use Corcel\Acf\Exception\MissingFieldNameException;
 use Corcel\Model;
 use Corcel\Model\Post;
 use Corcel\Model\Option;
+use Corcel\Acf\Models\AcfFieldGroup;
 
 class OptionPage extends Model
 {
+    /**
+     * @var string
+     */
     public $prefix;
 
+    /**
+     * @var AcfFieldGroup
+     */
     public $page;
 
     /**
@@ -18,11 +25,19 @@ class OptionPage extends Model
      */
     public $options;
 
-    public function __construct($prefix = 'options_')
+    /**
+     * TODO would be nice if only one of the arguments would be needed, but i
+     * dont see any connection between the page object in wp_posts and the
+     * prefix used in wp_options
+     *
+     * @param string $groupName acf field group name
+     * @param string $prefix prefix in wp_options
+     */
+    public function __construct($groupName, $prefix = 'options_')
     {
         parent::__construct();
         $this->prefix = $prefix;
-        $this->page = Post::where('post_excerpt', 'optionen')->first(); // FIXME
+        $this->page = AcfFieldGroup::where('post_title', $groupName)->first();
 
         $this->loadOptions();
     }

--- a/src/OptionPage.php
+++ b/src/OptionPage.php
@@ -32,7 +32,7 @@ class OptionPage extends Model
      */
     public function loadOptions()
     {
-        $builder = (new Option())->where('option_name', 'like', $this->prefix . '%');
+        $builder = Option::where('option_name', 'like', $this->prefix . '%');
         $this->options = $builder->get()->keyBy('option_name');
     }
 

--- a/src/OptionPage.php
+++ b/src/OptionPage.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Corcel\Acf;
+
+use Corcel\Acf\Exception\MissingFieldNameException;
+use Corcel\Model;
+use Corcel\Model\Post;
+use Corcel\Model\Option;
+
+class OptionPage extends Model
+{
+    public $prefix;
+
+    public $page;
+
+    /**
+     * @var Collection
+     */
+    public $options;
+
+    public function __construct($prefix = 'options_')
+    {
+        parent::__construct();
+        $this->prefix = $prefix;
+        $this->page = Post::where('post_excerpt', 'optionen')->first(); // FIXME
+
+        $this->loadOptions();
+    }
+
+    /**
+     * Load all options for this page into $this->options to save queries
+     */
+    public function loadOptions()
+    {
+        $builder = (new Option())->where('option_name', 'like', $this->prefix . '%');
+        $this->options = $builder->get()->keyBy('option_name');
+    }
+
+    /**
+     * Make possible to call $optionPage->fieldType('fieldName').
+     *
+     * @param string$name
+     * @param array $arguments
+     *
+     * @return mixed
+     *
+     * @throws MissingFieldNameException
+     */
+    public function __call($name, $arguments)
+    {
+        if (!isset($arguments[0])) {
+            throw new MissingFieldNameException('The field name is missing');
+        }
+
+        $field = FieldFactory::makeOptionField($arguments[0], $this, snake_case($name));
+
+        return $field ? $field->get() : null;
+    }
+}

--- a/src/OptionPage.php
+++ b/src/OptionPage.php
@@ -39,6 +39,10 @@ class OptionPage extends Model
         $this->prefix = $prefix;
         $this->page = AcfFieldGroup::where('post_title', $groupName)->first();
 
+        if (!$this->page) {
+            trigger_error('Could not instantiate option page called ' . $groupName);
+        }
+
         $this->loadOptions();
     }
 
@@ -47,7 +51,7 @@ class OptionPage extends Model
      */
     public function loadOptions()
     {
-        $builder = Option::where('option_name', 'like', $this->prefix . '%');
+        $builder = Option::where('option_name', 'like', $this->prefix . '%')->orWhere('option_name', 'like', '_' . $this->prefix . '%');
         $this->options = $builder->get()->keyBy('option_name');
     }
 
@@ -70,10 +74,5 @@ class OptionPage extends Model
         $field = FieldFactory::makeOptionField($arguments[0], $this, snake_case($name));
 
         return $field ? $field->get() : null;
-    }
-
-    public function getAcfField($fieldName)
-    {
-        return $this->page->children->where('post_excerpt', $fieldName)->first();
     }
 }

--- a/src/Repositories/OptionPageRepository.php
+++ b/src/Repositories/OptionPageRepository.php
@@ -42,7 +42,7 @@ class OptionPageRepository extends Repository
 
     public function getConnectionName()
     {
-        return 'wordpress'; // FIXME
+        return $this->optionPage->page->getConnectionName();
     }
 
     public function repeaterFetchFields(Repeater $repeater)

--- a/src/Repositories/OptionPageRepository.php
+++ b/src/Repositories/OptionPageRepository.php
@@ -31,12 +31,12 @@ class OptionPageRepository extends Repository
     }
 
     /**
-     * Convert a field name to its internal acf field name, e.g.
+     * Convert a field name to its internal acf field key, e.g.
      * "modules_1_text" => "field_588e076c2de43"
      *
      * @return string
      */
-    public function getAcfFieldName(string $fieldName)
+    public function getFieldKey(string $fieldName)
     {
         return $this->optionPage->options->get('_' . $this->optionPage->prefix . $fieldName)->value;
     }

--- a/src/Repositories/OptionPageRepository.php
+++ b/src/Repositories/OptionPageRepository.php
@@ -52,7 +52,7 @@ class OptionPageRepository extends Repository
 
         $count = (int) $this->fetchValue($fieldName);
 
-        $options = $this->optionPage->options->filter(function($option) use ($prefixedField) {
+        $options = $this->optionPage->options->filter(function ($option) use ($prefixedField) {
             return preg_match("/^${prefixedField}_\d+_/", $option->option_name);
         });
 
@@ -94,7 +94,7 @@ class OptionPageRepository extends Repository
         $fields = [];
         $blocks  = unserialize($this->fetchValue($fieldName));
 
-        $options = $this->optionPage->options->filter(function($option) use ($prefixedField) {
+        $options = $this->optionPage->options->filter(function ($option) use ($prefixedField) {
             return preg_match("/^${prefixedField}_/", $option->option_name);
         });
 

--- a/src/Repositories/OptionPageRepository.php
+++ b/src/Repositories/OptionPageRepository.php
@@ -69,8 +69,8 @@ class OptionPageRepository extends Repository
 
             // option_name is sth like "options_quicklinks_1_link"
 
-            $id = intval(str_replace("${prefixedField}_", '', $option->option_name)); // 1
-            $name = str_replace("${prefixedField}_${id}_", '', $option->option_name); // "link"
+            $id = $this->retrieveIdFromFieldName($option->option_name, $prefixedField); // 1
+            $name = $this->retrieveFieldName($option->option_name, $prefixedField, $id); // "link"
             $type = $types[$name]; // "page_link"
             $full = sprintf('%s_%d_%s', $fieldName, $id, $name); // "quicklinks_1_link"
 

--- a/src/Repositories/OptionPageRepository.php
+++ b/src/Repositories/OptionPageRepository.php
@@ -107,7 +107,6 @@ class OptionPageRepository extends Repository
         }
 
         foreach ($options as $option) {
-
             $id = $this->retrieveIdFromFieldName($option->option_name, $prefixedField); // 1
             $name = $this->retrieveFieldName($option->option_name, $prefixedField, $id); // "link"
             $type = $types[$name]; // "page_link"

--- a/src/Repositories/OptionPageRepository.php
+++ b/src/Repositories/OptionPageRepository.php
@@ -30,6 +30,14 @@ class OptionPageRepository extends Repository
     }
 
     /**
+     * @return Model
+     */
+    public function getPost($fieldName)
+    {
+        return $this->optionPage->getAcfField($fieldName);
+    }
+
+    /**
      * Get the value of a field from wp_options.
      *
      * @return string

--- a/src/Repositories/OptionPageRepository.php
+++ b/src/Repositories/OptionPageRepository.php
@@ -38,7 +38,7 @@ class OptionPageRepository extends Repository
      */
     public function getAcfFieldName(string $fieldName)
     {
-        return $this->optionPage->options->get('_' . $fieldName);
+        return $this->optionPage->options->get('_' . $this->optionPage->prefix . $fieldName)->value;
     }
 
     /**
@@ -73,9 +73,8 @@ class OptionPageRepository extends Repository
         });
 
         $types = [];
-        $repeater = $this->optionPage->getAcfField($fieldName);
 
-        $acfFields = AcfField::where('post_parent', $repeater->ID)->get();
+        $acfFields = $repeater->getAcfField()->children;
         foreach ($acfFields as $acfField) {
             $types[$acfField->post_excerpt] = $acfField->type;
         }
@@ -104,7 +103,7 @@ class OptionPageRepository extends Repository
 
     public function flexibleContentFetchFields(FlexibleContent $fc)
     {
-        $fieldName = $fc->name;
+        $fieldName = $fc->getFieldName();
         $prefixedField = $this->getPrefixedField($fieldName);
 
         $fields = [];
@@ -115,7 +114,7 @@ class OptionPageRepository extends Repository
         });
 
         $types = [];
-        $repeater = $this->optionPage->getAcfField($fieldName);
+        $repeater = $fc->getAcfField();
 
         $acfFields = AcfField::where('post_parent', $repeater->ID)->get();
         foreach ($acfFields as $acfField) {

--- a/src/Repositories/OptionPageRepository.php
+++ b/src/Repositories/OptionPageRepository.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Corcel\Acf\Repositories;
+
+use Corcel\Model\Option;
+use Corcel\Acf\Field\Repeater;
+use Corcel\Acf\Field\FlexibleContent;
+use Corcel\Acf\FieldFactory;
+use Corcel\Acf\Field\Text;
+use Corcel\Model\Post;
+use Corcel\Acf\OptionPage;
+
+class OptionPageRepository extends Repository
+{
+    /**
+     * OptionPage
+     */
+    protected $optionPage;
+
+    public function __construct(OptionPage $optionPage)
+    {
+        parent::__construct();
+        $this->optionPage = $optionPage;
+    }
+
+    protected function getPrefixedField($field)
+    {
+        return $this->optionPage->prefix . $field;
+    }
+
+    /**
+     * Get the value of a field from wp_options.
+     *
+     * @return string
+     */
+    public function fetchValue($field)
+    {
+        $prefixed = $this->getPrefixedField($field);
+        return $this->optionPage->options->get($prefixed)->option_value;
+    }
+
+    public function getConnectionName()
+    {
+        return 'wordpress'; // FIXME
+    }
+
+    public function repeaterFetchFields(Repeater $repeater)
+    {
+        $fieldName = $repeater->name;
+        $prefixedField = $this->getPrefixedField($fieldName);
+
+        $count = (int) $this->fetchValue($fieldName);
+
+        $options = $this->optionPage->options->filter(function($option) use ($prefixedField) {
+            return preg_match("/^${prefixedField}_\d+_/", $option->option_name);
+        });
+
+        $types = [];
+        $repeaterId = $this->optionPage->page->children->where('post_excerpt', $fieldName)->first()->ID;
+        // FIXME maybe we can use an own class for acfFields
+        $acfFields = (new Post())->where('post_parent', $repeaterId)->get();
+        foreach ($acfFields as $acfField) {
+            $types[$acfField->post_excerpt] = $this->fetchFieldType($acfField->post_name);
+        }
+
+        $fields = [];
+        foreach ($options as $option) {
+
+            // option_name is sth like "options_quicklinks_1_link"
+
+            $id = intval(str_replace("${prefixedField}_", '', $option->option_name)); // 1
+            $name = str_replace("${prefixedField}_${id}_", '', $option->option_name); // "link"
+            $type = $types[$name]; // "page_link"
+            $full = sprintf('%s_%d_%s', $fieldName, $id, $name); // "quicklinks_1_link"
+
+            $field = FieldFactory::makeOptionField($full, $this->optionPage, $type);
+
+            if ($field == null) {
+                continue;
+            }
+
+            $fields[$id][$name] = $field->get();
+        }
+
+        return $fields;
+    }
+
+    public function flexibleContentFetchFields(FlexibleContent $fc)
+    {
+        trigger_error('not implemented yet'); // FIXME
+    }
+}

--- a/src/Repositories/OptionPageRepository.php
+++ b/src/Repositories/OptionPageRepository.php
@@ -31,14 +31,6 @@ class OptionPageRepository extends Repository
     }
 
     /**
-     * @return Model
-     */
-    public function getPost($fieldName)
-    {
-        return $this->optionPage->getAcfField($fieldName);
-    }
-
-    /**
      * Convert a field name to its internal acf field name, e.g.
      * "modules_1_text" => "field_588e076c2de43"
      *

--- a/src/Repositories/OptionPageRepository.php
+++ b/src/Repositories/OptionPageRepository.php
@@ -10,6 +10,7 @@ use Corcel\Acf\Field\Text;
 use Corcel\Model\Post;
 use Corcel\Acf\OptionPage;
 use Corcel\Acf\Models\AcfField;
+use Corcel\Acf\Exception\MissingFieldException;
 
 class OptionPageRepository extends Repository
 {
@@ -45,7 +46,11 @@ class OptionPageRepository extends Repository
     public function fetchValue($field)
     {
         $prefixed = $this->getPrefixedField($field);
-        return $this->optionPage->options->get($prefixed)->option_value;
+        $option = $this->optionPage->options->get($prefixed);
+        if (!$option) {
+            throw new MissingFieldException('Field does not exist in option page: ' . $field);
+        }
+        return $option->option_value;
     }
 
     public function getConnectionName()

--- a/src/Repositories/OptionPageRepository.php
+++ b/src/Repositories/OptionPageRepository.php
@@ -9,6 +9,7 @@ use Corcel\Acf\FieldFactory;
 use Corcel\Acf\Field\Text;
 use Corcel\Model\Post;
 use Corcel\Acf\OptionPage;
+use Corcel\Acf\Models\AcfField;
 
 class OptionPageRepository extends Repository
 {
@@ -57,10 +58,10 @@ class OptionPageRepository extends Repository
 
         $types = [];
         $repeaterId = $this->optionPage->page->children->where('post_excerpt', $fieldName)->first()->ID;
-        // FIXME maybe we can use an own class for acfFields
-        $acfFields = (new Post())->where('post_parent', $repeaterId)->get();
+        
+        $acfFields = AcfField::where('post_parent', $repeaterId)->get();
         foreach ($acfFields as $acfField) {
-            $types[$acfField->post_excerpt] = $this->fetchFieldType($acfField->post_name);
+            $types[$acfField->post_excerpt] = $acfField->type;
         }
 
         $fields = [];

--- a/src/Repositories/OptionPageRepository.php
+++ b/src/Repositories/OptionPageRepository.php
@@ -39,6 +39,17 @@ class OptionPageRepository extends Repository
     }
 
     /**
+     * Convert a field name to its internal acf field name, e.g.
+     * "modules_1_text" => "field_588e076c2de43"
+     *
+     * @return string
+     */
+    public function getAcfFieldName(string $fieldName)
+    {
+        return $this->optionPage->options->get('_' . $fieldName);
+    }
+
+    /**
      * Get the value of a field from wp_options.
      *
      * @return string

--- a/src/Repositories/PostRepository.php
+++ b/src/Repositories/PostRepository.php
@@ -251,17 +251,6 @@ class PostRepository extends Repository
         return $fields;
     }
 
-    public function getFieldType($name)
-    {
-        $key = $this->getFieldKey($name);
-
-        if ($key === null) { // Field does not exist
-            return null;
-        }
-
-        return $this->fetchFieldType($key);
-    }
-
     /**
      * Convert a field name to its internal acf field key, e.g.
      * "my_image" => "field_588e076c2de43"

--- a/src/Repositories/PostRepository.php
+++ b/src/Repositories/PostRepository.php
@@ -85,22 +85,23 @@ class PostRepository extends Repository
      */
     public function fetchValue($field)
     {
-        $postMeta = $this->postMeta->where(
-           $this->getKeyName(), $this->post->getKey()
-        )->where('meta_key', $field)->first();
+        $value = $this->post->getMeta($field);
 
-        if (isset($postMeta->meta_value) and ! is_null($postMeta->meta_value)) {
-            $value = $postMeta->meta_value;
-            if ($array = @unserialize($value) and is_array($array)) {
-                $this->value = $array;
-
-                return $array;
-            } else {
-                $this->value = $value;
-
-                return $value;
-            }
+        // to stay backwards-compatible, return an empty string for unknown meta
+        // fields
+        if (is_null($value)) {
+            return '';
         }
+
+        if ($array = @unserialize($value) and is_array($array)) {
+            $this->value = $array;
+
+            return $array;
+        }
+
+
+        $this->value = $value;
+        return $value;
     }
 
     /**

--- a/src/Repositories/PostRepository.php
+++ b/src/Repositories/PostRepository.php
@@ -12,6 +12,7 @@ use Corcel\Model\Meta\UserMeta;
 use Corcel\Acf\FieldFactory;
 use Corcel\Acf\Field\Repeater;
 use Corcel\Acf\Field\FlexibleContent;
+use Corcel\Acf\Field\Text;
 
 class PostRepository extends Repository
 {
@@ -260,5 +261,17 @@ class PostRepository extends Repository
         ksort($fields);
 
         return $fields;
+    }
+
+    public function getFieldType($name)
+    {
+        $fakeText = new Text($this);
+        $key = $this->fetchFieldKey($name);
+
+        if ($key === null) { // Field does not exist
+            return null;
+        }
+
+        return $this->fetchFieldType($key);
     }
 }

--- a/src/Repositories/PostRepository.php
+++ b/src/Repositories/PostRepository.php
@@ -68,7 +68,7 @@ class PostRepository extends Repository
             $this->postMeta = new UserMeta();
         }
 
-        $this->postMeta->setConnection($post->getConnectionName());
+        $this->postMeta->setConnection($this->getConnectionName());
     }
 
     /**
@@ -165,5 +165,10 @@ class PostRepository extends Repository
         } elseif ($this->post instanceof User) {
             return 'user_id';
         }
+    }
+
+    public function getConnectionName()
+    {
+        return $this->post->getConnectionName();
     }
 }

--- a/src/Repositories/PostRepository.php
+++ b/src/Repositories/PostRepository.php
@@ -80,17 +80,17 @@ class PostRepository extends Repository
      * Get the value of a field according it's post ID.
      *
      * @param string $field
+     * @param mixed $defaultValue returned if the actual value is null, default
+     * to an empty string for backwards-compatibility
      *
      * @return array|string
      */
-    public function fetchValue($field)
+    public function fetchValue($field, $defaultValue = '')
     {
         $value = $this->post->getMeta($field);
 
-        // to stay backwards-compatible, return an empty string for unknown meta
-        // fields
         if (is_null($value)) {
-            return '';
+            return $defaultValue;
         }
 
         if ($array = @unserialize($value) and is_array($array)) {
@@ -211,7 +211,7 @@ class PostRepository extends Repository
         // blockField2, ...), "layoutblock2" => Collection(blockField)
 
         // get the actual layout blocks
-        $blocks  = $this->fetchValue($fieldName, $this->post);
+        $blocks  = $this->fetchValue($fieldName, []);
 
         $fields = [];
 

--- a/src/Repositories/PostRepository.php
+++ b/src/Repositories/PostRepository.php
@@ -222,7 +222,7 @@ class PostRepository extends Repository
             ->groupBy('content.parent_layout')
             // and now change the keys from the internal id ("5898b06bd55ed") to
             // the internal block name ("infobox")
-            ->keyBy(function($item, $key) use ($availableLayouts) {
+            ->keyBy(function ($item, $key) use ($availableLayouts) {
                 return $availableLayouts->get($key);
             });
 

--- a/src/Repositories/PostRepository.php
+++ b/src/Repositories/PostRepository.php
@@ -154,31 +154,6 @@ class PostRepository extends Repository
     }
 
     /**
-     * @param string $metaKey
-     * @param string $fieldName
-     *
-     * @return int
-     */
-    public function retrieveIdFromFieldName($metaKey, $fieldName)
-    {
-        return (int) str_replace("{$fieldName}_", '', $metaKey);
-    }
-
-    /**
-     * @param string $metaKey
-     * @param string $fieldName
-     * @param int    $id
-     *
-     * @return string
-     */
-    public function retrieveFieldName($metaKey, $fieldName, $id)
-    {
-        $pattern = "{$fieldName}_{$id}_";
-
-        return str_replace($pattern, '', $metaKey);
-    }
-
-    /**
      * @param $fieldName
      * @param $builder
      *

--- a/src/Repositories/PostRepository.php
+++ b/src/Repositories/PostRepository.php
@@ -237,9 +237,9 @@ class PostRepository extends Repository
 
         // loop through the blocks and fetch the respective values
         foreach ($blocks as $i => $block) {
-            $field = new \stdClass;
-            $field->type = $block;
-            $field->fields = new \stdClass;
+            $fieldData = new \stdClass;
+            $fieldData->type = $block;
+            $fieldData->fields = new \stdClass;
 
             $layoutFields = $layouts->get($block);
 
@@ -254,11 +254,17 @@ class PostRepository extends Repository
                     continue;
                 }
 
-                $tmp = FieldFactory::makeField($internalName, $this, $layoutField->type)->get();
-                $field->fields->$layoutFieldName = $tmp;
+                $field = FieldFactory::makeField($internalName, $this, $layoutField->type);
+
+                if (!$field) {
+                    trigger_error('Could not create field for ' . $internalName . ' with type ' . $layoutField->type, E_USER_NOTICE);
+                    continue;
+                }
+
+                $fieldData->fields->$layoutFieldName = $field->get();
             }
 
-            $fields[] = $field;
+            $fields[] = $fieldData;
         }
 
         ksort($fields);

--- a/src/Repositories/PostRepository.php
+++ b/src/Repositories/PostRepository.php
@@ -104,25 +104,13 @@ class PostRepository extends Repository
     }
 
     /**
-     * @param string $fieldName
+     * @deprecated in favor of getFieldKey
      *
      * @return string
      */
     public function fetchFieldKey($fieldName)
     {
-        $this->name = $fieldName;
-
-        $postMeta = $this->postMeta->where($this->getKeyName(), $this->post->getKey())
-            ->where('meta_key', '_' . $fieldName)
-            ->first();
-
-        if (!$postMeta) {
-            return null;
-        }
-
-        $this->key = $postMeta->meta_value;
-
-        return $this->key;
+        return $this->getFieldKey($fieldName);
     }
 
     /**
@@ -265,7 +253,7 @@ class PostRepository extends Repository
 
     public function getFieldType($name)
     {
-        $key = $this->fetchFieldKey($name);
+        $key = $this->getFieldKey($name);
 
         if ($key === null) { // Field does not exist
             return null;
@@ -275,12 +263,12 @@ class PostRepository extends Repository
     }
 
     /**
-     * Convert a field name to its internal acf field name, e.g.
+     * Convert a field name to its internal acf field key, e.g.
      * "my_image" => "field_588e076c2de43"
      *
      * @return string
      */
-    public function getAcfFieldName(string $fieldName)
+    public function getFieldKey(string $fieldName)
     {
         return $this->post->getMeta('_' . $fieldName);
     }

--- a/src/Repositories/PostRepository.php
+++ b/src/Repositories/PostRepository.php
@@ -193,6 +193,12 @@ class PostRepository extends Repository
         // content
         $acfField = $fc->getAcfField();
 
+        // if acf field is empty, it means there is no content. Directly return
+        // an empty array
+        if (empty($acfField)) {
+            return [];
+        }
+
         // all available layout blocks e.g. ["5898b06bd55ed" => "infobox"]
         $availableLayouts = collect($acfField->content['layouts'])->pluck('name', 'key');
 

--- a/src/Repositories/PostRepository.php
+++ b/src/Repositories/PostRepository.php
@@ -77,14 +77,6 @@ class PostRepository extends Repository
     }
 
     /**
-     * @return Model
-     */
-    public function getPost()
-    {
-        return $this->post;
-    }
-
-    /**
      * Get the value of a field according it's post ID.
      *
      * @param string $field

--- a/src/Repositories/PostRepository.php
+++ b/src/Repositories/PostRepository.php
@@ -197,12 +197,12 @@ class PostRepository extends Repository
      */
     public function flexibleContentFetchFields(FlexibleContent $fc)
     {
-        $fieldName = $fc->name;
+        $fieldName = $fc->getFieldName();
 
         // this is the acf field entry in wp_posts for the flexible content
         // field, which holds the possible layouts for this type of flexible
         // content
-        $acfField = $this->getAcfField($fieldName);
+        $acfField = $fc->getAcfField();
 
         // all available layout blocks e.g. ["5898b06bd55ed" => "infobox"]
         $availableLayouts = collect($acfField->content['layouts'])->pluck('name', 'key');

--- a/src/Repositories/PostRepository.php
+++ b/src/Repositories/PostRepository.php
@@ -132,29 +132,6 @@ class PostRepository extends Repository
     }
 
     /**
-     * @param string $fieldKey
-     *
-     * @return string|null
-     */
-    public function fetchFieldType($fieldKey)
-    {
-        $post = Post::on($this->post->getConnectionName())
-                   ->orWhere(function ($query) use ($fieldKey) {
-                       $query->where('post_name', $fieldKey);
-                       $query->where('post_type', 'acf-field');
-                   })->first();
-
-        if ($post) {
-            $fieldData = unserialize($post->post_content);
-            $this->type = isset($fieldData['type']) ? $fieldData['type'] : 'text';
-
-            return $this->type;
-        }
-
-        return null;
-    }
-
-    /**
      * Get the name of the key for the field.
      *
      * @return string

--- a/src/Repositories/PostRepository.php
+++ b/src/Repositories/PostRepository.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Corcel\Acf\Repositories;
+
+use Corcel\Model\Post;
+use Corcel\Model;
+use Corcel\Model\Meta\PostMeta;
+use Corcel\Model\Term;
+use Corcel\Model\Meta\TermMeta;
+use Corcel\Model\User;
+use Corcel\Model\Meta\UserMeta;
+
+class PostRepository extends Repository
+{
+    /**
+     * @var Model
+     */
+    protected $post;
+
+    /**
+     * @var PostMeta
+     */
+    protected $postMeta;
+
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var string
+     */
+    protected $key;
+
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @var mixed
+     */
+    protected $value;
+
+    /**
+     * @var string
+     */
+    protected $connection;
+
+    public function __construct(Model $post)
+    {
+        parent::__construct();
+        $this->setPost($post);
+    }
+
+    /**
+     * Sets the post instance and its according postMeta
+     */
+    public function setPost(Model $post)
+    {
+        $this->post = $post;
+
+        if ($post instanceof Post) {
+            $this->postMeta = new PostMeta();
+        } elseif ($post instanceof Term) {
+            $this->postMeta = new TermMeta();
+        } elseif ($post instanceof User) {
+            $this->postMeta = new UserMeta();
+        }
+
+        $this->postMeta->setConnection($post->getConnectionName());
+    }
+
+    /**
+     * @return Model
+     */
+    public function getPost()
+    {
+        return $this->post;
+    }
+
+    /**
+     * Get the value of a field according it's post ID.
+     *
+     * @param string $field
+     *
+     * @return array|string
+     */
+    public function fetchValue($field)
+    {
+        $postMeta = $this->postMeta->where(
+           $this->getKeyName(), $this->post->getKey()
+        )->where('meta_key', $field)->first();
+
+        if (isset($postMeta->meta_value) and ! is_null($postMeta->meta_value)) {
+            $value = $postMeta->meta_value;
+            if ($array = @unserialize($value) and is_array($array)) {
+                $this->value = $array;
+
+                return $array;
+            } else {
+                $this->value = $value;
+
+                return $value;
+            }
+        }
+    }
+
+    /**
+     * @param string $fieldName
+     *
+     * @return string
+     */
+    public function fetchFieldKey($fieldName)
+    {
+        $this->name = $fieldName;
+
+        $postMeta = $this->postMeta->where($this->getKeyName(), $this->post->getKey())
+            ->where('meta_key', '_' . $fieldName)
+            ->first();
+
+        if (!$postMeta) {
+            return null;
+        }
+
+        $this->key = $postMeta->meta_value;
+
+        return $this->key;
+    }
+
+    /**
+     * @param string $fieldKey
+     *
+     * @return string|null
+     */
+    public function fetchFieldType($fieldKey)
+    {
+        $post = Post::on($this->post->getConnectionName())
+                   ->orWhere(function ($query) use ($fieldKey) {
+                       $query->where('post_name', $fieldKey);
+                       $query->where('post_type', 'acf-field');
+                   })->first();
+
+        if ($post) {
+            $fieldData = unserialize($post->post_content);
+            $this->type = isset($fieldData['type']) ? $fieldData['type'] : 'text';
+
+            return $this->type;
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the name of the key for the field.
+     *
+     * @return string
+     */
+    public function getKeyName()
+    {
+        if ($this->post instanceof Post) {
+            return 'post_id';
+        } elseif ($this->post instanceof Term) {
+            return 'term_id';
+        } elseif ($this->post instanceof User) {
+            return 'user_id';
+        }
+    }
+}

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -35,4 +35,29 @@ abstract class Repository
 
         return $field->type;
     }
+
+    /**
+     * @param string $metaKey
+     * @param string $fieldName
+     *
+     * @return int
+     */
+    public function retrieveIdFromFieldName($metaKey, $fieldName)
+    {
+        return (int) str_replace("{$fieldName}_", '', $metaKey);
+    }
+
+    /**
+     * @param string $metaKey
+     * @param string $fieldName
+     * @param int    $id
+     *
+     * @return string
+     */
+    public function retrieveFieldName($metaKey, $fieldName, $id)
+    {
+        $pattern = "{$fieldName}_{$id}_";
+
+        return str_replace($pattern, '', $metaKey);
+    }
 }

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -20,7 +20,7 @@ abstract class Repository
     abstract public function repeaterFetchFields(Repeater $repeater);
     abstract public function flexibleContentFetchFields(FlexibleContent $fc);
 
-    abstract public function getAcfFieldName(string $fieldName);
+    abstract public function getFieldKey(string $fieldName);
 
     /**
      * @param string $fieldKey

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Corcel\Acf\Repositories;
+
+class Repository
+{
+    public function __construct()
+    {
+    }
+}

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -5,6 +5,7 @@ namespace Corcel\Acf\Repositories;
 use Corcel\Model\Post;
 use Corcel\Acf\Field\Repeater;
 use Corcel\Acf\Field\FlexibleContent;
+use Corcel\Acf\Models\AcfField;
 
 abstract class Repository
 {
@@ -26,19 +27,12 @@ abstract class Repository
      */
     public function fetchFieldType($fieldKey)
     {
-        $post = Post::on($this->getConnectionName())
-                   ->orWhere(function ($query) use ($fieldKey) {
-                       $query->where('post_name', $fieldKey);
-                       $query->where('post_type', 'acf-field');
-                   })->first();
+        $field = AcfField::where('post_name', $fieldKey)->first();
 
-        if ($post) {
-            $fieldData = unserialize($post->post_content);
-            $this->type = isset($fieldData['type']) ? $fieldData['type'] : 'text';
-
-            return $this->type;
+        if (!$field) {
+            return null;
         }
 
-        return null;
+        return $field->type;
     }
 }

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -2,9 +2,34 @@
 
 namespace Corcel\Acf\Repositories;
 
+use Corcel\Model\Post;
+
 class Repository
 {
     public function __construct()
     {
+    }
+
+    /**
+     * @param string $fieldKey
+     *
+     * @return string|null
+     */
+    public function fetchFieldType($fieldKey)
+    {
+        $post = Post::on($this->getConnectionName())
+                   ->orWhere(function ($query) use ($fieldKey) {
+                       $query->where('post_name', $fieldKey);
+                       $query->where('post_type', 'acf-field');
+                   })->first();
+
+        if ($post) {
+            $fieldData = unserialize($post->post_content);
+            $this->type = isset($fieldData['type']) ? $fieldData['type'] : 'text';
+
+            return $this->type;
+        }
+
+        return null;
     }
 }

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -22,14 +22,15 @@ abstract class Repository
 
     abstract public function getFieldKey(string $fieldName);
 
-    /**
-     * @param string $fieldKey
-     *
-     * @return string|null
-     */
-    public function fetchFieldType($fieldKey)
+    public function getFieldType($fieldName)
     {
-        $field = AcfField::where('post_name', $fieldKey)->first();
+        $key = $this->getFieldKey($fieldName);
+
+        if ($key === null) { // Field does not exist
+            return null;
+        }
+
+        $field = AcfField::where('post_name', $key)->first();
 
         if (!$field) {
             return null;

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -3,12 +3,21 @@
 namespace Corcel\Acf\Repositories;
 
 use Corcel\Model\Post;
+use Corcel\Acf\Field\Repeater;
+use Corcel\Acf\Field\FlexibleContent;
 
-class Repository
+abstract class Repository
 {
     public function __construct()
     {
     }
+
+    abstract public function fetchValue($field);
+
+    abstract public function getConnectionName();
+
+    abstract public function repeaterFetchFields(Repeater $repeater);
+    abstract public function flexibleContentFetchFields(FlexibleContent $fc);
 
     /**
      * @param string $fieldKey

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -20,6 +20,19 @@ abstract class Repository
     abstract public function repeaterFetchFields(Repeater $repeater);
     abstract public function flexibleContentFetchFields(FlexibleContent $fc);
 
+    abstract public function getAcfFieldName(string $fieldName);
+
+    /**
+     * Get a AcfField for a certain field name
+     *
+     * @return AcfField
+     */
+    public function getAcfField(string $fieldName)
+    {
+        $acfFieldName = $this->getAcfFieldName($fieldName);
+        return AcfField::where('post_name', $acfFieldName)->first();
+    }
+
     /**
      * @param string $fieldKey
      *

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -23,17 +23,6 @@ abstract class Repository
     abstract public function getAcfFieldName(string $fieldName);
 
     /**
-     * Get a AcfField for a certain field name
-     *
-     * @return AcfField
-     */
-    public function getAcfField(string $fieldName)
-    {
-        $acfFieldName = $this->getAcfFieldName($fieldName);
-        return AcfField::where('post_name', $acfFieldName)->first();
-    }
-
-    /**
      * @param string $fieldKey
      *
      * @return string|null

--- a/tests/BasicFieldsTest.php
+++ b/tests/BasicFieldsTest.php
@@ -2,13 +2,15 @@
 
 use Corcel\Acf\Field\Text;
 use Corcel\Model\Post;
+use Corcel\Acf\Tests\TestCase;
+use Corcel\Acf\Repositories\PostRepository;
 
 /**
  * Class BasicFieldTest.
  *
  * @author Junior Grossi <juniorgro@gmail.com>
  */
-class BasicFieldsTest extends PHPUnit_Framework_TestCase
+class BasicFieldsTest extends TestCase
 {
     /**
      * @var Post
@@ -20,12 +22,15 @@ class BasicFieldsTest extends PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->post = Post::find(11); // it' a page with the custom fields
+        parent::setUp();
+
+        $post = $this->createAcfPost();
+        $this->repo = new PostRepository($post);
     }
 
     public function testTextFieldValue()
     {
-        $text = new Text($this->post);
+        $text = new Text($this->repo);
         $text->process('fake_text');
 
         $this->assertEquals('Proin eget tortor risus', $text->get());
@@ -33,7 +38,7 @@ class BasicFieldsTest extends PHPUnit_Framework_TestCase
 
     public function testTextareaFieldValue()
     {
-        $textarea = new Text($this->post);
+        $textarea = new Text($this->repo);
         $textarea->process('fake_textarea');
 
         $this->assertEquals('Praesent sapien massa, convallis a pellentesque nec, egestas non nisi.', $textarea->get());
@@ -41,7 +46,7 @@ class BasicFieldsTest extends PHPUnit_Framework_TestCase
 
     public function testNumberFieldValue()
     {
-        $number = new Text($this->post);
+        $number = new Text($this->repo);
         $number->process('fake_number');
 
         $this->assertEquals('1984', $number->get());
@@ -49,7 +54,7 @@ class BasicFieldsTest extends PHPUnit_Framework_TestCase
 
     public function testEmailFieldValue()
     {
-        $email = new Text($this->post);
+        $email = new Text($this->repo);
         $email->process('fake_email');
 
         $this->assertEquals('junior@corcel.org', $email->get());
@@ -57,7 +62,7 @@ class BasicFieldsTest extends PHPUnit_Framework_TestCase
 
     public function testUrlFieldValue()
     {
-        $url = new Text($this->post);
+        $url = new Text($this->repo);
         $url->process('fake_url');
 
         $this->assertEquals('https://corcel.org', $url->get());
@@ -65,7 +70,7 @@ class BasicFieldsTest extends PHPUnit_Framework_TestCase
 
     public function testPasswordFieldValue()
     {
-        $password = new Text($this->post);
+        $password = new Text($this->repo);
         $password->process('fake_password');
 
         $this->assertEquals('123change', $password->get());

--- a/tests/BasicFieldsTest.php
+++ b/tests/BasicFieldsTest.php
@@ -13,9 +13,9 @@ use Corcel\Acf\Repositories\PostRepository;
 class BasicFieldsTest extends TestCase
 {
     /**
-     * @var Post
+     * @var PostRepository
      */
-    protected $post;
+    protected $repo;
 
     /**
      * Setup a base $this->post object to represent the page with the basic fields.
@@ -26,6 +26,22 @@ class BasicFieldsTest extends TestCase
 
         $post = $this->createAcfPost();
         $this->repo = new PostRepository($post);
+    }
+
+    /**
+     * Create a sample post with acf fields
+     */
+    protected function createAcfPost()
+    {
+        $post = factory(Post::class)->create();
+        $this->createAcfField($post, 'fake_text', 'Proin eget tortor risus');
+        $this->createAcfField($post, 'fake_textarea', 'Praesent sapien massa, convallis a pellentesque nec, egestas non nisi.', 'textarea');
+        $this->createAcfField($post, 'fake_number', '1984', 'number');
+        $this->createAcfField($post, 'fake_email', 'junior@corcel.org', 'email');
+        $this->createAcfField($post, 'fake_url', 'https://corcel.org', 'url');
+        $this->createAcfField($post, 'fake_password', '123change', 'password');
+
+        return $post;
     }
 
     public function testTextFieldValue()

--- a/tests/ChoicesFieldsTest.php
+++ b/tests/ChoicesFieldsTest.php
@@ -14,15 +14,31 @@ use Corcel\Acf\Repositories\PostRepository;
 class ChoicesFieldsTest extends TestCase
 {
     /**
-     * @var Post
+     * @var PostRepository
      */
-    protected $post;
+    protected $repo;
 
     public function setUp()
     {
         parent::setUp();
         $post = $this->createAcfPost();
         $this->repo = new PostRepository($post);
+    }
+
+    /**
+     * Create a sample post with acf fields
+     */
+    protected function createAcfPost()
+    {
+        $post = factory(Post::class)->create();
+
+        $this->createAcfField($post, 'fake_select', 'red', 'select');
+        $this->createAcfField($post, 'fake_select_multiple', serialize(['yellow', 'green']), 'select_multiple');
+        $this->createAcfField($post, 'fake_checkbox', serialize(['blue', 'yellow']), 'checkbox');
+        $this->createAcfField($post, 'fake_radio_button', 'green', 'radio_button');
+        $this->createAcfField($post, 'fake_true_false', '1', 'true_false');
+
+        return $post;
     }
 
     public function testSelectField()

--- a/tests/ChoicesFieldsTest.php
+++ b/tests/ChoicesFieldsTest.php
@@ -3,13 +3,15 @@
 use Corcel\Acf\Field\Boolean;
 use Corcel\Acf\Field\Text;
 use Corcel\Model\Post;
+use Corcel\Acf\Tests\TestCase;
+use Corcel\Acf\Repositories\PostRepository;
 
 /**
  * Class ChoicesFieldsTest.
  *
  * @author Junior Grossi <juniorgro@gmail.com>
  */
-class ChoicesFieldsTest extends PHPUnit_Framework_TestCase
+class ChoicesFieldsTest extends TestCase
 {
     /**
      * @var Post
@@ -18,40 +20,42 @@ class ChoicesFieldsTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->post = Post::find(44);
+        parent::setUp();
+        $post = $this->createAcfPost();
+        $this->repo = new PostRepository($post);
     }
 
     public function testSelectField()
     {
-        $select = new Text($this->post);
+        $select = new Text($this->repo);
         $select->process('fake_select');
         $this->assertEquals('red', $select->get());
     }
 
     public function testSelectMultipleField()
     {
-        $select = new Text($this->post);
+        $select = new Text($this->repo);
         $select->process('fake_select_multiple');
         $this->assertEquals(['yellow', 'green'], $select->get());
     }
 
     public function testCheckboxField()
     {
-        $check = new Text($this->post);
+        $check = new Text($this->repo);
         $check->process('fake_checkbox');
         $this->assertEquals(['blue', 'yellow'], $check->get());
     }
 
     public function testRadioField()
     {
-        $radio = new Text($this->post);
+        $radio = new Text($this->repo);
         $radio->process('fake_radio_button');
         $this->assertEquals('green', $radio->get());
     }
 
     public function testTrueFalseField()
     {
-        $boolean = new Boolean($this->post);
+        $boolean = new Boolean($this->repo);
         $boolean->process('fake_true_false');
         $this->assertTrue($boolean->get());
     }

--- a/tests/CloneFieldTest.php
+++ b/tests/CloneFieldTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use Corcel\Acf\Field\DateTime;
+use Corcel\Acf\Field\Text;
+use Corcel\Acf\Field\CloneField;
+use Corcel\Model\Post;
+use Corcel\Acf\Tests\TestCase;
+use Corcel\Acf\Models\AcfField;
+
+class CloneFieldTests extends TestCase
+{
+    /**
+     * @var Post
+     */
+    protected $post;
+
+    /**
+     * Setup a base $this->post object to represent the page with the content fields.
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->post = $this->createAcfPost();
+    }
+
+    /**
+     * Create a sample post with acf fields
+     */
+    protected function createAcfPost()
+    {
+        $post = factory(Post::class)->create();
+
+        $this->createAcfField($post, 'fake_date_picker', '20161013', 'date_picker');
+
+        $acffield = factory(AcfField::class)->create();
+        $cloned = $this->createAcfField($post, 'fake_date_picker2', '20161013', 'date_picker', [], 'field_xdferfdsdertd_' . $acffield->post_name);
+
+        return $post;
+    }
+
+    public function testCloneField()
+    {
+        $clone = new CloneField($this->post);
+        $clone->process('fake_date_picker');
+        $this->assertInstanceOf(\Carbon\Carbon::class, $clone->get());
+        $this->assertEquals('10/13/2016', $clone->get()->format('m/d/Y'));
+    }
+}

--- a/tests/ContentFieldsTest.php
+++ b/tests/ContentFieldsTest.php
@@ -54,7 +54,7 @@ class ContentFieldsTest extends TestCase
         ]);
         $this->createAcfField($post, 'fake_file', $file->ID, 'file');
 
-        $galleryImages = factory(Attachment::class, 7)->create()->each(function($image) {
+        $galleryImages = factory(Attachment::class, 7)->create()->each(function ($image) {
             $image->meta()->save(factory(PostMeta::class)->states('attachment_metadata')->create());
         });
         $this->createAcfField($post, 'fake_gallery', serialize($galleryImages->pluck('ID')), 'gallery');

--- a/tests/ContentFieldsTest.php
+++ b/tests/ContentFieldsTest.php
@@ -5,30 +5,66 @@ use Corcel\Acf\Field\Gallery;
 use Corcel\Acf\Field\Image;
 use Corcel\Acf\Field\Text;
 use Corcel\Model\Post;
+use Corcel\Acf\Repositories\PostRepository;
+use Corcel\Acf\Tests\TestCase;
+use Corcel\Model\Attachment;
+use Corcel\Model\Meta\PostMeta;
 
 /**
  * Class ContentFieldsTest.
  *
  * @author Junior Grossi <juniorgro@gmail.com>
  */
-class ContentFieldsTest extends PHPUnit_Framework_TestCase
+class ContentFieldsTest extends TestCase
 {
     /**
-     * @var Post
+     * @var PostRepository
      */
-    protected $post;
+    protected $repo;
 
     /**
      * Setup a base $this->post object to represent the page with the content fields.
      */
     protected function setUp()
     {
-        $this->post = Post::find(21); // it' a page with the custom fields
+        parent::setUp();
+        $post = $this->createAcfPost();
+        $this->repo = new PostRepository($post);
+    }
+
+    /**
+     * Create a sample post with acf fields
+     */
+    protected function createAcfPost()
+    {
+        $post = factory(Post::class)->create();
+        $this->createAcfField($post, 'fake_editor', 'Nulla <em>porttitor</em> <del>accumsan</del> <strong>tincidunt</strong>. Sed porttitor lectus nibh.', 'editor');
+
+        $this->createAcfField($post, 'fake_oembed', 'https://www.youtube.com/watch?v=LiyQ8bvLzIE', 'oembed');
+
+        $image = factory(Attachment::class)->create(['post_excerpt' => 'This is a caption.']);
+        $image->meta()->save(factory(PostMeta::class)->states('attachment_metadata')->create());
+        $this->createAcfField($post, 'fake_image', $image->ID, 'image');
+
+        $file = factory(Attachment::class)->states('file')->create([
+            'post_content' => 'Description here',
+            'post_title' => 'Title here',
+            'post_excerpt' => 'Caption here',
+            'guid' => 'http://wordpress.corcel.dev/wp-content/uploads/2016/10/Consolidado-Manifestacao-do-Conselho-Deliberativo.pdf',
+        ]);
+        $this->createAcfField($post, 'fake_file', $file->ID, 'file');
+
+        $galleryImages = factory(Attachment::class, 7)->create()->each(function($image) {
+            $image->meta()->save(factory(PostMeta::class)->states('attachment_metadata')->create());
+        });
+        $this->createAcfField($post, 'fake_gallery', serialize($galleryImages->pluck('ID')), 'gallery');
+
+        return $post;
     }
 
     public function testEditorFieldValue()
     {
-        $field = new Text($this->post);
+        $field = new Text($this->repo);
         $field->process('fake_editor');
 
         $this->assertEquals(
@@ -39,7 +75,7 @@ class ContentFieldsTest extends PHPUnit_Framework_TestCase
 
     public function testOembedFieldValue()
     {
-        $field = new Text($this->post);
+        $field = new Text($this->repo);
         $field->process('fake_oembed');
 
         $this->assertEquals('https://www.youtube.com/watch?v=LiyQ8bvLzIE', $field->get());
@@ -47,7 +83,7 @@ class ContentFieldsTest extends PHPUnit_Framework_TestCase
 
     public function testImageFieldValue()
     {
-        $image = new Image($this->post);
+        $image = new Image($this->repo);
         $image->process('fake_image');
 
         $this->assertEquals('1920', $image->width);
@@ -68,12 +104,12 @@ class ContentFieldsTest extends PHPUnit_Framework_TestCase
         $this->assertNotEmpty($image->size('fake_size', true)->url);
 
         $this->assertEquals('image/jpeg', $image->mime_type);
-        $this->assertEquals('This is a caption', $image->description);
+        $this->assertEquals('This is a caption.', $image->description);
     }
 
     public function testFileFieldValue()
     {
-        $file = new File($this->post);
+        $file = new File($this->repo);
         $file->process('fake_file');
 
         $this->assertEquals('Description here', $file->description);
@@ -85,7 +121,7 @@ class ContentFieldsTest extends PHPUnit_Framework_TestCase
 
     public function testGalleryFieldValue()
     {
-        $gallery = new Gallery($this->post);
+        $gallery = new Gallery($this->repo);
         $gallery->process('fake_gallery');
 
         $this->assertEquals(7, $gallery->get()->count());

--- a/tests/CorcelIntegrationTest.php
+++ b/tests/CorcelIntegrationTest.php
@@ -1,30 +1,50 @@
 <?php
 
 use Corcel\Model\Post;
+use Corcel\Acf\Tests\TestCase;
+use Corcel\Model\User;
 
 /**
  * Class CorcelIntegrationTest.
  *
  * @author Junior Grossi <juniorgro@gmail.com>
  */
-class CorcelIntegrationTest extends PHPUnit_Framework_TestCase
+class CorcelIntegrationTest extends TestCase
 {
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->post = $this->createAcfPost();
+    }
+
+    /**
+     * Create a sample post with acf fields
+     */
+    protected function createAcfPost()
+    {
+        $post = factory(Post::class)->create();
+
+        $user = factory(User::class)->create();
+        $this->createAcfField($post, 'fake_user', $user->ID, 'user');
+
+        $this->createAcfField($post, 'fake_date_picker', '20161013', 'date_picker');
+
+        return $post;
+    }
+
     public function testIfCorcelIntegrationIsWorking()
     {
-        $post = Post::find(56);
-        $this->assertEquals('admin', $post->acf->fake_user->nickname);
+        $this->assertInstanceOf(User::class, $this->post->acf->fake_user);
     }
 
     public function testUsageOfHelperFunctions()
     {
-        $post = Post::find(56);
-        $this->assertEquals('admin', $post->acf->user('fake_user')->nickname);
+        $this->assertInstanceOf(User::class, $this->post->acf->user('fake_user'));
     }
 
     public function testFunctionHelperWithSnakeCaseFieldType()
     {
-        $post = Post::find(65);
-        $this->assertEquals('10/13/2016', $post->acf->fake_date_picker->format('m/d/Y'));
-        $this->assertEquals('10/13/2016', $post->acf->datePicker('fake_date_picker')->format('m/d/Y'));
+        $this->assertEquals('10/13/2016', $this->post->acf->fake_date_picker->format('m/d/Y'));
+        $this->assertEquals('10/13/2016', $this->post->acf->datePicker('fake_date_picker')->format('m/d/Y'));
     }
 }

--- a/tests/EmptyBasicFieldsTest.php
+++ b/tests/EmptyBasicFieldsTest.php
@@ -3,30 +3,50 @@
 use Corcel\Acf\Field\Text;
 use Corcel\Acf\Field\BasicField;
 use Corcel\Model\Post;
+use Corcel\Acf\Tests\TestCase;
+use Corcel\Acf\Repositories\PostRepository;
 
 /**
  * Class BasicFieldTest.
  *
  * @author Junior Grossi <juniorgro@gmail.com>
  */
-class EmptyBasicFieldsTest extends PHPUnit_Framework_TestCase
+class EmptyBasicFieldsTest extends TestCase
 {
     /**
-     * @var Post
+     * @var PostRepository
      */
-    protected $post;
+    protected $repo;
 
     /**
-     * Setup a base $this->post object to represent the page with the basic fields.
+     * Setup a base $this->post object to represent the page with the content fields.
      */
     protected function setUp()
     {
-        $this->post = Post::find(91); // it' a page with empty custom fields
+        parent::setUp();
+        $post = $this->createAcfPost();
+        $this->repo = new PostRepository($post);
+    }
+
+    /**
+     * Create a sample post with acf fields
+     */
+    protected function createAcfPost()
+    {
+        $post = factory(Post::class)->create();
+        $this->createAcfField($post, 'fake_text', '');
+        $this->createAcfField($post, 'fake_textarea', '', 'textarea');
+        $this->createAcfField($post, 'fake_number', '', 'number');
+        $this->createAcfField($post, 'fake_email', '', 'email');
+        $this->createAcfField($post, 'fake_url', '', 'url');
+        $this->createAcfField($post, 'fake_password', '', 'password');
+
+        return $post;
     }
 
     public function testTextFieldValue()
     {
-        $text = new Text($this->post);
+        $text = new Text($this->repo);
         $text->process('fake_text');
 
         $this->assertSame('', $text->get());
@@ -34,7 +54,7 @@ class EmptyBasicFieldsTest extends PHPUnit_Framework_TestCase
 
     public function testTextareaFieldValue()
     {
-        $textarea = new Text($this->post);
+        $textarea = new Text($this->repo);
         $textarea->process('fake_textarea');
 
         $this->assertSame('', $textarea->get());
@@ -42,7 +62,7 @@ class EmptyBasicFieldsTest extends PHPUnit_Framework_TestCase
 
     public function testNumberFieldValue()
     {
-        $number = new Text($this->post);
+        $number = new Text($this->repo);
         $number->process('fake_number');
 
         $this->assertSame('', $number->get());
@@ -50,7 +70,7 @@ class EmptyBasicFieldsTest extends PHPUnit_Framework_TestCase
 
     public function testEmailFieldValue()
     {
-        $email = new Text($this->post);
+        $email = new Text($this->repo);
         $email->process('fake_email');
 
         $this->assertSame('', $email->get());
@@ -58,7 +78,7 @@ class EmptyBasicFieldsTest extends PHPUnit_Framework_TestCase
 
     public function testUrlFieldValue()
     {
-        $url = new Text($this->post);
+        $url = new Text($this->repo);
         $url->process('fake_url');
 
         $this->assertSame('', $url->get());
@@ -66,7 +86,7 @@ class EmptyBasicFieldsTest extends PHPUnit_Framework_TestCase
 
     public function testPasswordFieldValue()
     {
-        $password = new Text($this->post);
+        $password = new Text($this->repo);
         $password->process('fake_password');
 
         $this->assertSame('', $password->get());

--- a/tests/FieldFactoryTest.php
+++ b/tests/FieldFactoryTest.php
@@ -2,82 +2,113 @@
 
 use Corcel\Acf\FieldFactory;
 use Corcel\Model\Post;
+use Corcel\Acf\Tests\TestCase;
+use Corcel\Model\Attachment;
+use Corcel\Model\Meta\PostMeta;
 
 /**
  * Class FieldFactoryTest.
  *
  * @author Junior Grossi <juniorgro@gmail.com>
  */
-class FieldFactoryTest extends PHPUnit_Framework_TestCase
+class FieldFactoryTest extends TestCase
 {
+    /**
+     * @var Post
+     */
+    protected $post;
+
+    /**
+     * Setup a base $this->post object to represent the page with the content fields.
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->post = $this->createAcfPost();
+    }
+
+    /**
+     * Create a sample post with acf fields
+     */
+    protected function createAcfPost()
+    {
+        $post = factory(Post::class)->create();
+        $this->createAcfField($post, 'fake_text', 'Proin eget tortor risus');
+        $this->createAcfField($post, 'fake_textarea', 'Praesent sapien massa, convallis a pellentesque nec, egestas non nisi.', 'textarea');
+        $this->createAcfField($post, 'fake_number', '1984', 'number');
+        $this->createAcfField($post, 'fake_email', 'junior@corcel.org', 'email');
+        $this->createAcfField($post, 'fake_url', 'https://corcel.org', 'url');
+        $this->createAcfField($post, 'fake_password', '123change', 'password');
+
+        $this->createAcfField($post, 'fake_editor', 'Nulla <em>porttitor</em> <del>accumsan</del> <strong>tincidunt</strong>. Sed porttitor lectus nibh.', 'editor');
+
+        $this->createAcfField($post, 'fake_oembed', 'https://www.youtube.com/watch?v=LiyQ8bvLzIE', 'oembed');
+
+        $image = factory(Attachment::class)->create(['post_excerpt' => 'This is a caption.']);
+        $image->meta()->save(factory(PostMeta::class)->states('attachment_metadata')->create());
+        $this->createAcfField($post, 'fake_image', $image->ID, 'image');
+
+        return $post;
+    }
+
     public function testInvalidFieldName()
     {
-        $post = Post::find(11);
-        $invalidField = FieldFactory::make('invalid_field', $post);
+        $invalidField = FieldFactory::make('invalid_field', $this->post);
         $this->assertNull($invalidField);
     }
 
     public function testTextField()
     {
-        $post = Post::find(11);
-        $text = FieldFactory::make('fake_text', $post);
+        $text = FieldFactory::make('fake_text', $this->post);
         $this->assertEquals('Proin eget tortor risus', $text->get());
     }
 
     public function testTextareaField()
     {
-        $post = Post::find(11);
-        $textarea = FieldFactory::make('fake_textarea', $post);
+        $textarea = FieldFactory::make('fake_textarea', $this->post);
         $this->assertTrue(is_string($textarea->get()));
         $this->assertTrue(strlen($textarea->get()) > 0);
     }
 
     public function testNumberField()
     {
-        $post = Post::find(11);
-        $number = FieldFactory::make('fake_number', $post);
+        $number = FieldFactory::make('fake_number', $this->post);
         $this->assertTrue(is_numeric($number->get()));
     }
 
     public function testEmailField()
     {
-        $post = Post::find(11);
-        $email = FieldFactory::make('fake_email', $post);
+        $email = FieldFactory::make('fake_email', $this->post);
         $this->assertEquals('junior@corcel.org', $email->get());
     }
 
     public function testUrlField()
     {
-        $post = Post::find(11);
-        $url = FieldFactory::make('fake_url', $post);
+        $url = FieldFactory::make('fake_url', $this->post);
         $this->assertEquals('https://corcel.org', $url->get());
     }
 
     public function testPasswordField()
     {
-        $post = Post::find(11);
-        $password = FieldFactory::make('fake_password', $post);
+        $password = FieldFactory::make('fake_password', $this->post);
         $this->assertEquals('123change', $password->get());
     }
 
     public function testEditorField()
     {
-        $post = Post::find(21);
-        $editor = FieldFactory::make('fake_editor', $post);
+        $editor = FieldFactory::make('fake_editor', $this->post);
         $this->assertNotFalse(strpos($editor->get(), '<em>'));
     }
 
     public function testOembedField()
     {
-        $post = Post::find(21);
-        $embed = FieldFactory::make('fake_oembed', $post);
+        $embed = FieldFactory::make('fake_oembed', $this->post);
         $this->assertNotFalse(strpos($embed->get(), 'youtube.com'));
     }
 
     public function testImageField()
     {
-        $post = Post::find(21);
-        $image = FieldFactory::make('fake_image', $post);
+        $image = FieldFactory::make('fake_image', $this->post);
         $this->assertTrue(is_numeric($image->get()->width));
         $this->assertTrue(is_numeric($image->get()->height));
         $this->assertNotFalse(strpos($image->get()->url, 'http'));

--- a/tests/JqueryFieldsTest.php
+++ b/tests/JqueryFieldsTest.php
@@ -3,22 +3,45 @@
 use Corcel\Acf\Field\DateTime;
 use Corcel\Acf\Field\Text;
 use Corcel\Model\Post;
+use Corcel\Acf\Tests\TestCase;
 
-class JqueryFieldsTests extends PHPUnit_Framework_TestCase
+class JqueryFieldsTests extends TestCase
 {
     /**
      * @var Post
      */
     protected $post;
 
-    public function setUp()
+    /**
+     * Setup a base $this->post object to represent the page with the content fields.
+     */
+    protected function setUp()
     {
-        $this->post = Post::find(65);
+        parent::setUp();
+        $this->post = $this->createAcfPost();
+    }
+
+    /**
+     * Create a sample post with acf fields
+     */
+    protected function createAcfPost()
+    {
+        $post = factory(Post::class)->create();
+
+        $this->createAcfField($post, 'fake_date_picker', '20161013', 'date_picker');
+        $this->createAcfField($post, 'fake_date_time_picker', '2016-10-19 08:06:05', 'date_time_picker');
+        $this->createAcfField($post, 'fake_time_picker', '17:30:00', 'time_picker');
+        $this->createAcfField($post, 'fake_color_picker', '#7263a8', 'color_picker');
+
+        return $post;
     }
 
     public function testGoogleMapField()
     {
         // Google Map field is not working at this moment
+        $this->markTestIncomplete(
+          'This test has not been implemented yet.'
+        );
     }
 
     public function testDatePickerField()

--- a/tests/LayoutFieldsTest.php
+++ b/tests/LayoutFieldsTest.php
@@ -60,10 +60,40 @@ class LayoutFieldsTest extends TestCase
         // flexible content
         $post2 = factory(Post::class)->create();
         $posts = factory(Post::class, 2)->create();
-        $this->createAcfField($post, 'fake_flexible_content', 'a:3:{i:0;s:11:"normal_text";i:1;s:12:"related_post";i:2;s:14:"multiple_posts";}', 'flexible_content');
-        $this->createAcfField($post, 'fake_flexible_content_0_text', 'Lorem ipsum');
-        $this->createAcfField($post, 'fake_flexible_content_1_post', $post2->ID, 'post_object');
-        $this->createAcfField($post, 'fake_flexible_content_2_post', serialize($posts->pluck('ID')->toArray()), 'post_object');
+        $rootAcf = $this->createAcfField($post, 'fake_flexible_content', 'a:3:{i:0;s:11:"normal_text";i:1;s:12:"related_post";i:2;s:14:"multiple_posts";}', 'flexible_content');
+        $this->createAcfField(
+            $post,
+            'fake_flexible_content_0_text',
+            'Lorem ipsum',
+            [],
+            [
+                'post_parent' => $rootAcf->ID,
+                'post_content' => 'a:11:{s:4:"type";s:4:"text";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:13:"parent_layout";s:13:"589c18bcf10da";s:13:"default_value";s:0:"";s:11:"placeholder";s:0:"";s:7:"prepend";s:0:"";s:6:"append";s:0:"";s:9:"maxlength";s:0:"";}',
+                'post_excerpt' => 'text',
+            ]
+        );
+        $this->createAcfField(
+            $post,
+            'fake_flexible_content_1_post',
+            $post2->ID,
+            'post_object',
+            [
+                'post_parent' => $rootAcf->ID,
+                'post_content' => 'a:12:{s:4:"type";s:11:"post_object";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:13:"parent_layout";s:13:"589c18dfc9b28";s:9:"post_type";a:0:{}s:8:"taxonomy";a:0:{}s:10:"allow_null";i:0;s:8:"multiple";i:0;s:13:"return_format";s:6:"object";s:2:"ui";i:1;}',
+                'post_excerpt' => 'post',
+            ]
+        );
+        $this->createAcfField(
+            $post,
+            'fake_flexible_content_2_post',
+            serialize($posts->pluck('ID')->toArray()),
+            'post_object',
+            [
+                'post_parent' => $rootAcf->ID,
+                'post_content' => 'a:12:{s:4:"type";s:11:"post_object";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:13:"parent_layout";s:13:"589c1ee35ec27";s:9:"post_type";a:0:{}s:8:"taxonomy";a:0:{}s:10:"allow_null";i:0;s:8:"multiple";i:1;s:13:"return_format";s:6:"object";s:2:"ui";i:1;}',
+                'post_excerpt' => 'post',
+            ]
+        );
 
 
         return $post;
@@ -100,9 +130,6 @@ class LayoutFieldsTest extends TestCase
         $flex = new FlexibleContent($this->post);
         $flex->process('fake_flexible_content');
         $layout = $flex->get();
-
-        // FIXME this test has be changed to work with the new & fixed flexible
-        // content
 
         $this->assertEquals(3, $layout->count());
 

--- a/tests/LayoutFieldsTest.php
+++ b/tests/LayoutFieldsTest.php
@@ -3,16 +3,20 @@
 use Corcel\Acf\Field\Repeater;
 use Corcel\Acf\Field\FlexibleContent;
 use Corcel\Model\Post;
+use Corcel\Acf\Tests\TestCase;
 
 /**
  * Class LayoutFieldsTest.
  *
  * @author Junior Grossi <juniorgro@gmail.com>
  */
-class LayoutFieldsTest extends PHPUnit_Framework_TestCase
+class LayoutFieldsTest extends TestCase
 {
     public function testRepeaterField()
     {
+        // FIXME
+        $this->markTestIncomplete('This test has not been implemented yet.');
+
         $page = Post::find(73);
         $repeater = new Repeater($page);
         $repeater->process('fake_repeater');
@@ -26,6 +30,9 @@ class LayoutFieldsTest extends PHPUnit_Framework_TestCase
 
     public function testComplexRepeaterField()
     {
+        // FIXME
+        $this->markTestIncomplete('This test has not been implemented yet.');
+
         $page = Post::find(73);
         $repeater = new Repeater($page);
         $repeater->process('fake_repeater_2');
@@ -42,6 +49,9 @@ class LayoutFieldsTest extends PHPUnit_Framework_TestCase
 
     public function testFlexibleContentField()
     {
+        // FIXME
+        $this->markTestIncomplete('This test has not been implemented yet.');
+
         $page = Post::find(86);
         $flex = new FlexibleContent($page);
         $flex->process('fake_flexible_content');

--- a/tests/LayoutFieldsTest.php
+++ b/tests/LayoutFieldsTest.php
@@ -101,6 +101,9 @@ class LayoutFieldsTest extends TestCase
         $flex->process('fake_flexible_content');
         $layout = $flex->get();
 
+        // FIXME this test has be changed to work with the new & fixed flexible
+        // content
+
         $this->assertEquals(3, $layout->count());
 
         $this->assertEquals('normal_text', $layout[0]->type);

--- a/tests/LayoutFieldsTest.php
+++ b/tests/LayoutFieldsTest.php
@@ -4,6 +4,8 @@ use Corcel\Acf\Field\Repeater;
 use Corcel\Acf\Field\FlexibleContent;
 use Corcel\Model\Post;
 use Corcel\Acf\Tests\TestCase;
+use Corcel\Model\User;
+use Corcel\Model\Attachment;
 
 /**
  * Class LayoutFieldsTest.
@@ -12,13 +14,64 @@ use Corcel\Acf\Tests\TestCase;
  */
 class LayoutFieldsTest extends TestCase
 {
+    /**
+     * @var Post
+     */
+    protected $post;
+
+    /**
+     * Setup a base $this->post object to represent the page with the content fields.
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->post = $this->createAcfPost();
+    }
+
+    /**
+     * Create a sample post with acf fields
+     */
+    protected function createAcfPost()
+    {
+        $post = factory(Post::class)->create();
+
+        // repeater #1
+        $this->createAcfField($post, 'fake_repeater', '2', 'repeater');
+        $this->createAcfField($post, 'fake_repeater_0_repeater_text', 'First text');
+        $this->createAcfField($post, 'fake_repeater_0_repeater_radio', 'blue', 'radio_button');
+        $this->createAcfField($post, 'fake_repeater_1_repeater_text', 'Second text');
+        $this->createAcfField($post, 'fake_repeater_1_repeater_radio', 'red', 'radio_button');
+
+
+        // repeater #1
+        $users = factory(User::class, 2)->create();
+        $files = factory(Attachment::class, 2)->states('file')->create();
+        $relationships = factory(Post::class, 5)->states('page')->create();
+
+        $this->createAcfField($post, 'fake_repeater_2', '2', 'repeater');
+        $this->createAcfField($post, 'fake_repeater_2_0_fake_user', $users->first()->ID, 'user');
+        $this->createAcfField($post, 'fake_repeater_2_0_fake_file', $files->first()->ID, 'file');
+        $this->createAcfField($post, 'fake_repeater_2_0_fake_relationship', serialize($relationships->take(2)->pluck('ID')), 'relationship');
+        $this->createAcfField($post, 'fake_repeater_2_1_fake_user', $users->last()->ID, 'user');
+        $this->createAcfField($post, 'fake_repeater_2_1_fake_file', $files->last()->ID, 'file');
+        $this->createAcfField($post, 'fake_repeater_2_1_fake_relationship', serialize($relationships->take(1)->pluck('ID')), 'relationship');
+
+
+        // flexible content
+        $post2 = factory(Post::class)->create();
+        $posts = factory(Post::class, 2)->create();
+        $this->createAcfField($post, 'fake_flexible_content', 'a:3:{i:0;s:11:"normal_text";i:1;s:12:"related_post";i:2;s:14:"multiple_posts";}', 'flexible_content');
+        $this->createAcfField($post, 'fake_flexible_content_0_text', 'Lorem ipsum');
+        $this->createAcfField($post, 'fake_flexible_content_1_post', $post2->ID, 'post_object');
+        $this->createAcfField($post, 'fake_flexible_content_2_post', serialize($posts->pluck('ID')->toArray()), 'post_object');
+
+
+        return $post;
+    }
+
     public function testRepeaterField()
     {
-        // FIXME
-        $this->markTestIncomplete('This test has not been implemented yet.');
-
-        $page = Post::find(73);
-        $repeater = new Repeater($page);
+        $repeater = new Repeater($this->post);
         $repeater->process('fake_repeater');
         $fields = $repeater->get()->toArray();
 
@@ -30,17 +83,12 @@ class LayoutFieldsTest extends TestCase
 
     public function testComplexRepeaterField()
     {
-        // FIXME
-        $this->markTestIncomplete('This test has not been implemented yet.');
-
-        $page = Post::find(73);
-        $repeater = new Repeater($page);
+        $repeater = new Repeater($this->post);
         $repeater->process('fake_repeater_2');
         $fields = $repeater->get()->toArray();
 
-
-        $this->assertEquals('admin', $fields[0]['fake_user']->nickname);
-        $this->assertEquals('admin', $fields[1]['fake_user']->nickname);
+        $this->assertEquals('admin', $fields[0]['fake_user']->user_login);
+        $this->assertEquals('admin', $fields[1]['fake_user']->user_login);
         $this->assertEquals(2, $fields[0]['fake_relationship']->count());
         $this->assertEquals(1, $fields[1]['fake_relationship']->count());
         $this->assertInstanceOf(Post::class, $fields[0]['fake_relationship']->first());
@@ -49,11 +97,7 @@ class LayoutFieldsTest extends TestCase
 
     public function testFlexibleContentField()
     {
-        // FIXME
-        $this->markTestIncomplete('This test has not been implemented yet.');
-
-        $page = Post::find(86);
-        $flex = new FlexibleContent($page);
+        $flex = new FlexibleContent($this->post);
         $flex->process('fake_flexible_content');
         $layout = $flex->get();
 

--- a/tests/OptionPageRepositoryTest.php
+++ b/tests/OptionPageRepositoryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use Corcel\Model\Post;
+use Corcel\Acf\Tests\TestCase;
+use Corcel\Acf\Repositories\OptionPageRepository;
+use Corcel\Acf\Models\AcfFieldGroup;
+use Corcel\Acf\OptionPage;
+
+class OptionPageRepositoryTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $title = 'test-options';
+        $prefix = 'options_';
+
+        $post = factory(AcfFieldGroup::class)->create(['post_title' => $title]);
+
+        $post2 = factory(Post::class)->create(['post_title' => 'Test post', 'ID' => 33]);
+        $this->createOptionAcfField($post, $prefix, 'fake_post_object', $post2->ID, 'post_object', [], 'field_0123456789abc');
+
+        $optionPage = new OptionPage($title, $prefix);
+        $this->repo = new OptionPageRepository($optionPage);
+    }
+
+    public function testGetFieldKey()
+    {
+        $this->assertEquals('field_0123456789abc', $this->repo->getFieldKey('fake_post_object'));
+    }
+
+    public function testFetchValue()
+    {
+        $this->assertEquals('33', $this->repo->fetchValue('fake_post_object'));
+    }
+
+    public function testGetConnectionName()
+    {
+        $this->assertEquals('wp', $this->repo->getConnectionName('fake_oembed'));
+    }
+}

--- a/tests/OptionPageTest.php
+++ b/tests/OptionPageTest.php
@@ -1,0 +1,227 @@
+<?php
+
+use Corcel\Acf\Field\Repeater;
+use Corcel\Acf\Field\FlexibleContent;
+use Corcel\Model\Post;
+use Corcel\Model\Page;
+use Corcel\Acf\Tests\TestCase;
+use Corcel\Model\User;
+use Corcel\Model\Attachment;
+use Corcel\Acf\OptionPage;
+use Corcel\Acf\Models\AcfFieldGroup;
+use Corcel\Model\Meta\PostMeta;
+use Corcel\Acf\Field\File;
+use Corcel\Acf\Field\Gallery;
+use Corcel\Acf\Field\Image;
+use Corcel\Acf\Field\Text;
+use Corcel\Acf\Exception\MissingFieldException;
+use Corcel\Model\User as CorcelUser;
+use Corcel\Model\Term as CorcelTerm;
+
+class OptionPageTest extends TestCase
+{
+    /**
+     * @var Post
+     */
+    protected $post;
+
+    /**
+     * Setup a base $this->post object to represent the page with the content fields.
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+    }
+
+    /**
+     * Create a sample post with acf fields
+     */
+    protected function createAcfPost($title, $prefix = 'options_')
+    {
+        $post = factory(AcfFieldGroup::class)->create(['post_title' => $title]);
+
+        $this->createOptionAcfField($post, $prefix, 'fake_email', 'junior@corcel.org', 'email');
+
+        $image = factory(Attachment::class)->create(['post_excerpt' => 'This is a caption.']);
+        $image->meta()->save(factory(PostMeta::class)->states('attachment_metadata')->create());
+        $this->createOptionAcfField($post, $prefix, 'fake_image', $image->ID, 'image');
+
+        $file = factory(Attachment::class)->states('file')->create();
+        $this->createOptionAcfField($post, $prefix, 'fake_file', $file->ID, 'file');
+
+        $galleryImages = factory(Attachment::class, 7)->create()->each(function ($image) {
+            $image->meta()->save(factory(PostMeta::class)->states('attachment_metadata')->create());
+        });
+        $this->createOptionAcfField($post, $prefix, 'fake_gallery', serialize($galleryImages->pluck('ID')), 'gallery');
+
+        $this->createOptionAcfField($post, $prefix, 'fake_true_false', '1', 'true_false');
+
+        $post2 = factory(Post::class)->create(['post_title' => 'Test post']);
+        $this->createOptionAcfField($post, $prefix, 'fake_post_object', $post2->ID, 'post_object');
+
+        $page2 = factory(Post::class)->states('page')->create([
+            'guid' => 'http://wordpress.corcel.dev/?page_id=21',
+            'post_name' => 'test-slug',
+        ]);
+        $this->createOptionAcfField($post, $prefix, 'fake_page_link', $page2->ID, 'page_link');
+
+        $term = factory(CorcelTerm::class)->create(['slug' => 'uncategorized']);
+        $this->createOptionAcfField($post, $prefix, 'fake_taxonomy_single', $term->term_id, 'taxonomy_single');
+
+        $user = factory(CorcelUser::class)->create(['user_login' => 'admin']);
+        $this->createOptionAcfField($post, $prefix, 'fake_user', $user->ID, 'user');
+
+        $this->createOptionAcfField($post, $prefix, 'fake_date_time_picker', '2016-10-19 08:06:05', 'date_time_picker');
+
+
+        return $post;
+    }
+
+    protected function createOptionPage($title = 'Test-Options', $prefix = 'options_')
+    {
+        $post = $this->createAcfPost($title, $prefix);
+        return new OptionPage($title, $prefix);
+    }
+
+    public function testPrefix()
+    {
+        $post = $this->createAcfPost('Test', 'test-prefix');
+
+        $page = new OptionPage('test', 'test-prefix');
+        $page->loadOptions();
+        // $this->assertEquals(2, $page->options->count());
+
+        $pageInvalid = new OptionPage('test', $post);
+        $pageInvalid->loadOptions();
+        $this->assertEquals(0, $pageInvalid->options->count());
+    }
+
+    public function testAcfField()
+    {
+        $page = $this->createOptionPage();
+
+        $field = $page->getAcfField('fake_email');
+
+        $this->assertInstanceOf(Post::class, $field);
+        $this->assertEquals('acf-field', $field->post_type);
+    }
+
+    public function testMissingField()
+    {
+        $page = $this->createOptionPage();
+        $this->expectException(MissingFieldException::class);
+        $page->text('missing-field');
+    }
+
+    public function testText()
+    {
+        $page = $this->createOptionPage();
+        $this->assertEquals('junior@corcel.org', $page->text('fake_email'));
+    }
+
+    public function testImage()
+    {
+        $page = $this->createOptionPage();
+
+        $image = $page->image('fake_image');
+
+        $this->assertInstanceOf(Image::class, $image);
+
+        $this->assertEquals('1920', $image->width);
+        $this->assertEquals('1080', $image->height);
+        $this->assertEquals('maxresdefault-1.jpg', $image->filename);
+
+        // Test existing image size
+        $this->assertEquals('1024', $image->size('large')->width);
+        $this->assertNotEmpty($image->size('large')->url);
+
+        // Test non existing image size with thumbnail as fallback
+        $this->assertEquals('150', $image->size('fake_size')->width);
+        $this->assertNotEmpty($image->size('fake_size')->url);
+
+        // Test non existing image size with original as fallback
+        $this->assertEquals($image->width, $image->size('fake_size', true)->width);
+        $this->assertEquals($image->height, $image->size('fake_size', true)->height);
+        $this->assertNotEmpty($image->size('fake_size', true)->url);
+
+        $this->assertEquals('image/jpeg', $image->mime_type);
+        $this->assertEquals('This is a caption.', $image->description);
+    }
+
+    public function testFile()
+    {
+        $page = $this->createOptionPage();
+        $file = $page->file('fake_file');
+
+        $this->assertInstanceOf(File::class, $file);
+        $this->assertEquals('application/pdf', $file->mime_type);
+    }
+
+    public function testGallery()
+    {
+        $page = $this->createOptionPage();
+        $gallery = $page->gallery('fake_gallery');
+
+        $this->assertEquals(7, $gallery->count());
+
+        /** @var Image $image */
+        foreach ($gallery as $image) {
+            $this->assertTrue($image->width > 0);
+            $this->assertTrue($image->height > 0);
+            $this->assertTrue(strlen($image->url) > 0);
+        }
+
+        // Testing the image in the 6th position
+        $image = $gallery->get(6);
+        $this->assertEquals(1920, $image->width);
+        $this->assertEquals(1080, $image->height);
+
+    }
+
+    public function testBoolean()
+    {
+        $page = $this->createOptionPage();
+        $this->assertTrue($page->boolean('fake_true_false'));
+    }
+
+    public function testPostobject()
+    {
+        $page = $this->createOptionPage();
+        $post = $page->post_object('fake_post_object');
+        $this->assertInstanceOf(Post::class, $post);
+        $this->assertEquals('Test post', $post->post_title);
+    }
+
+    public function testPagelink()
+    {
+        $page = $this->createOptionPage();
+        $link = $page->page_link('fake_page_link');
+        $this->assertEquals('http://wordpress.corcel.dev/test-slug/', $link);
+    }
+
+    public function testTerm()
+    {
+        $page = $this->createOptionPage();
+        $term = $page->term('fake_taxonomy_single');
+        $this->assertInstanceOf(CorcelTerm::class, $term);
+        $this->assertEquals('uncategorized', $term->slug);
+    }
+
+    public function testUser()
+    {
+        $page = $this->createOptionPage();
+        $user = $page->user('fake_user');
+        $this->assertInstanceOf(CorcelUser::class, $user);
+        $this->assertEquals('admin', $user->user_login);
+
+    }
+
+    public function testDatetime()
+    {
+        $page = $this->createOptionPage();
+        $datetime = $page->date_time_picker('fake_date_time_picker');
+        $this->assertInstanceOf(\Carbon\Carbon::class, $datetime);
+        $this->assertEquals('05:06:08/19-10:2016', $datetime->format('s:i:H/d-m:Y'));
+    }
+
+}

--- a/tests/OptionPageTest.php
+++ b/tests/OptionPageTest.php
@@ -175,7 +175,6 @@ class OptionPageTest extends TestCase
         $image = $gallery->get(6);
         $this->assertEquals(1920, $image->width);
         $this->assertEquals(1080, $image->height);
-
     }
 
     public function testBoolean()
@@ -213,7 +212,6 @@ class OptionPageTest extends TestCase
         $user = $page->user('fake_user');
         $this->assertInstanceOf(CorcelUser::class, $user);
         $this->assertEquals('admin', $user->user_login);
-
     }
 
     public function testDatetime()
@@ -223,5 +221,4 @@ class OptionPageTest extends TestCase
         $this->assertInstanceOf(\Carbon\Carbon::class, $datetime);
         $this->assertEquals('05:06:08/19-10:2016', $datetime->format('s:i:H/d-m:Y'));
     }
-
 }

--- a/tests/OptionPageTest.php
+++ b/tests/OptionPageTest.php
@@ -89,7 +89,7 @@ class OptionPageTest extends TestCase
 
         $page = new OptionPage('test', 'test-prefix');
         $page->loadOptions();
-        $this->assertEquals(10, $page->options->count());
+        $this->assertEquals(20, $page->options->count());
     }
 
     public function testMissingField()

--- a/tests/OptionPageTest.php
+++ b/tests/OptionPageTest.php
@@ -85,25 +85,11 @@ class OptionPageTest extends TestCase
 
     public function testPrefix()
     {
-        $post = $this->createAcfPost('Test', 'test-prefix');
+        $post = $this->createAcfPost('test', 'test-prefix');
 
         $page = new OptionPage('test', 'test-prefix');
         $page->loadOptions();
-        // $this->assertEquals(2, $page->options->count());
-
-        $pageInvalid = new OptionPage('test', $post);
-        $pageInvalid->loadOptions();
-        $this->assertEquals(0, $pageInvalid->options->count());
-    }
-
-    public function testAcfField()
-    {
-        $page = $this->createOptionPage();
-
-        $field = $page->getAcfField('fake_email');
-
-        $this->assertInstanceOf(Post::class, $field);
-        $this->assertEquals('acf-field', $field->post_type);
+        $this->assertEquals(10, $page->options->count());
     }
 
     public function testMissingField()

--- a/tests/PostRepositoryTest.php
+++ b/tests/PostRepositoryTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use Corcel\Model\Post;
+use Corcel\Acf\Tests\TestCase;
+use Corcel\Acf\Repositories\PostRepository;
+
+class PostRepositoryTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $post = factory(Post::class)->create();
+        $this->createAcfField($post, 'fake_oembed', 'https://www.youtube.com/watch?v=LiyQ8bvLzIE', 'oembed', [], 'field_1234567890abc');
+
+        $this->repo = new PostRepository($post);
+    }
+
+    public function testGetFieldKey()
+    {
+        $this->assertEquals('field_1234567890abc', $this->repo->getFieldKey('fake_oembed'));
+    }
+
+    public function testGetFieldType()
+    {
+        $this->assertEquals('oembed', $this->repo->getFieldType('fake_oembed'));
+    }
+
+    public function testFetchValue()
+    {
+        $this->assertEquals('https://www.youtube.com/watch?v=LiyQ8bvLzIE', $this->repo->fetchValue('fake_oembed'));
+    }
+
+    public function testGetKeyName()
+    {
+        $this->assertEquals('post_id', $this->repo->getKeyName('fake_oembed'));
+    }
+
+    public function testGetConnectionName()
+    {
+        $this->assertEquals('wp', $this->repo->getConnectionName('fake_oembed'));
+    }
+
+}

--- a/tests/RelationalFieldsTest.php
+++ b/tests/RelationalFieldsTest.php
@@ -5,22 +5,63 @@ use Corcel\Acf\Field\PostObject;
 use Corcel\Acf\Field\Term;
 use Corcel\Acf\Field\User;
 use Corcel\Model\Post;
+use Corcel\Acf\Tests\TestCase;
+use Corcel\Model\User as CorcelUser;
+use Corcel\Model\Term as CorcelTerm;
 
 /**
  * Class RelationalFieldsTests.
  *
  * @author Junior Grossi <juniorgro@gmail.com>
  */
-class RelationalFieldsTests extends PHPUnit_Framework_TestCase
+class RelationalFieldsTests extends TestCase
 {
     /**
      * @var Post
      */
     protected $post;
 
-    public function setUp()
+    /**
+     * Setup a base $this->post object to represent the page with the content fields.
+     */
+    protected function setUp()
     {
-        $this->post = Post::find(56);
+        parent::setUp();
+        $this->post = $this->createAcfPost();
+    }
+
+    /**
+     * Create a sample post with acf fields
+     */
+    protected function createAcfPost()
+    {
+        $post = factory(Post::class)->create();
+
+        $post2 = factory(Post::class)->create(['post_title' => 'ACF Basic Fields']);
+        $this->createAcfField($post, 'fake_post_object', $post2->ID, 'post_object');
+
+        $page = factory(Post::class)->states('page')->create([
+            'guid' => 'http://wordpress.corcel.dev/?page_id=21',
+            'post_name' => 'acf-content-fields',
+        ]);
+        $this->createAcfField($post, 'fake_page_link', $page->ID, 'page_link');
+
+        $pageIds = [];
+        $pageIds[] = factory(Post::class)->states('page')->create(['post_title' => 'test #1'])->ID;
+        $pageIds[] = factory(Post::class)->states('page')->create(['post_title' => 'test #2'])->ID;
+        $this->createAcfField($post, 'fake_relationship', serialize($pageIds), 'relationship');
+
+        $term = factory(CorcelTerm::class)->create(['slug' => 'uncategorized']);
+        $this->createAcfField($post, 'fake_taxonomy_single', $term->term_id, 'taxonomy_single');
+
+        $term2 = factory(CorcelTerm::class)->create(['slug' => 'test-term']);
+        $this->createAcfField($post, 'fake_taxonomy', serialize([$term->term_id, $term2->term_id]), 'taxonomy');
+
+
+        $user = factory(CorcelUser::class)->create(['user_login' => 'admin']);
+        $this->createAcfField($post, 'fake_user', $user->ID, 'user');
+
+        return $post;
     }
 
     public function testPostObjectField()
@@ -42,7 +83,7 @@ class RelationalFieldsTests extends PHPUnit_Framework_TestCase
         $relation = new PostObject($this->post);
         $relation->process('fake_relationship');
         $posts = $relation->get();
-        $this->assertEquals([44, 56], $posts->pluck('ID')->toArray());
+        $this->assertEquals(['test #1', 'test #2'], $posts->pluck('post_title')->toArray());
     }
 
     public function testTaxonomyField()
@@ -51,6 +92,7 @@ class RelationalFieldsTests extends PHPUnit_Framework_TestCase
 
         $relation->process('fake_taxonomy'); // multiple (Collection)
         $this->assertEquals('uncategorized', $relation->get()->first()->slug);
+        $this->assertEquals('test-term', $relation->get()->last()->slug);
 
         $relation->process('fake_taxonomy_single'); // single (Corcel\Term)
         $this->assertEquals('uncategorized', $relation->get()->slug);
@@ -61,6 +103,5 @@ class RelationalFieldsTests extends PHPUnit_Framework_TestCase
         $user = new User($this->post);
         $user->process('fake_user');
         $this->assertEquals('admin', $user->get()->user_login);
-        $this->assertEquals('admin', $user->get()->nickname);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,8 @@ use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use Corcel\Model\Post;
 use Corcel\Model\Meta\PostMeta;
 use Corcel\Acf\Models\AcfField;
+use Corcel\Acf\Models\AcfFieldGroup;
+use Corcel\Model\Option;
 
 class TestCase extends OrchestraTestCase
 {
@@ -80,6 +82,26 @@ class TestCase extends OrchestraTestCase
         ]);
 
         $override['post_name'] = $internal;
+
+        $acffield = factory(AcfField::class)->states($states)->create($override);
+        return $acffield;
+    }
+
+    /**
+     * Create an acf field for use in an option page
+     */
+    protected function createOptionAcfField(AcfFieldGroup $fieldGroup, $prefix, $fieldName, $value, $states = [], $override = [])
+    {
+        $internal = 'field_' . str_random(13);
+
+        factory(Option::class)->create([
+            'option_name' => $prefix . $fieldName,
+            'option_value' => $value,
+        ]);
+
+        $override['post_name'] = $internal;
+        $override['post_parent'] = $fieldGroup->ID;
+        $override['post_excerpt'] = $fieldName;
 
         $acffield = factory(AcfField::class)->states($states)->create($override);
         return $acffield;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -75,9 +75,11 @@ class TestCase extends OrchestraTestCase
         $this->createAcfField($post, 'fake_url', 'https://corcel.org', 'url');
         $this->createAcfField($post, 'fake_password', '123change', 'password');
 
-        $attachment = factory(Attachment::class)->create();
-        $attachment->meta()->save(factory(PostMeta::class)->states('attachment_metadata')->create());
-        $this->createAcfField($post, 'test-image', $attachment->ID, 'image');
+        $this->createAcfField($post, 'fake_select', 'red', 'select');
+        $this->createAcfField($post, 'fake_select_multiple', serialize(['yellow', 'green']), 'select_multiple');
+        $this->createAcfField($post, 'fake_checkbox', serialize(['blue', 'yellow']), 'checkbox');
+        $this->createAcfField($post, 'fake_radio_button', 'green', 'radio_button');
+        $this->createAcfField($post, 'fake_true_false', '1', 'true_false');
 
         return $post;
     }
@@ -85,7 +87,7 @@ class TestCase extends OrchestraTestCase
     /**
      * Create a acf field for a post with a field name and a value
      */
-    protected function createAcfField(Post $post, $fieldName, $value, $type = 'text', $override = [])
+    protected function createAcfField(Post $post, $fieldName, $value, $states = [], $override = [])
     {
         $internal = 'field_' . str_random(13);
 
@@ -101,9 +103,8 @@ class TestCase extends OrchestraTestCase
         ]);
 
         $override['post_name'] = $internal;
-        $override['post_excerpt'] = $type;
 
-        $acffield = factory(AcfField::class)->create($override);
+        $acffield = factory(AcfField::class)->states($states)->create($override);
         return $acffield;
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Corcel\Acf\Tests;
+
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use Corcel\Model\Attachment;
+use Corcel\Model\Post;
+use Corcel\Model\Meta\PostMeta;
+use Corcel\Acf\Models\AcfField;
+
+class TestCase extends OrchestraTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        // FIXME we load migrations and factories from corcel, but is that
+        // really better than copying it over here?
+        $this->pathPrefix = '/../../../jgrossi/corcel';
+
+        // --realpath can be used once we upgrade to 5.6
+        $this->loadMigrationsFrom([
+            '--database' => 'foo',
+            '--path' => $this->pathPrefix.'/tests/database/migrations',
+        ]);
+
+        $this->loadMigrationsFrom([
+            '--database' => 'wp',
+            '--path' => $this->pathPrefix.'/tests/database/migrations',
+        ]);
+
+        $this->withFactories(base_path() . '/' .$this->pathPrefix.'/tests/database/factories');
+        $this->withFactories(__DIR__ . '/database/factories');
+    }
+
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $this->configureDatabaseConfig($app);
+    }
+
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     */
+    private function configureDatabaseConfig($app)
+    {
+        // dd(base_path());
+        $app['config']->set('database.connections.wp', [
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => 'wp_',
+        ]);
+
+        $app['config']->set('database.connections.foo', [
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => 'foo_',
+        ]);
+
+        $app['config']->set('database.default', 'wp');
+    }
+
+    /**
+     * Create a sample post with acf fields
+     */
+    protected function createAcfPost()
+    {
+        $post = factory(Post::class)->create();
+        $this->createAcfField($post, 'fake_text', 'Proin eget tortor risus');
+        $this->createAcfField($post, 'fake_textarea', 'Praesent sapien massa, convallis a pellentesque nec, egestas non nisi.', 'textarea');
+        $this->createAcfField($post, 'fake_number', '1984', 'number');
+        $this->createAcfField($post, 'fake_email', 'junior@corcel.org', 'email');
+        $this->createAcfField($post, 'fake_url', 'https://corcel.org', 'url');
+        $this->createAcfField($post, 'fake_password', '123change', 'password');
+
+        $attachment = factory(Attachment::class)->create();
+        $attachment->meta()->save(factory(PostMeta::class)->states('attachment_metadata')->create());
+        $this->createAcfField($post, 'test-image', $attachment->ID, 'image');
+
+        return $post;
+    }
+
+    /**
+     * Create a acf field for a post with a field name and a value
+     */
+    protected function createAcfField(Post $post, $fieldName, $value, $type = 'text', $override = [])
+    {
+        $internal = 'field_' . str_random(13);
+
+        $postmeta1 = factory(PostMeta::class)->create([
+            'post_id' => $post->ID,
+            'meta_key' => $fieldName,
+            'meta_value' => $value,
+        ]);
+        $postmeta2 = factory(PostMeta::class)->create([
+            'post_id' => $post->ID,
+            'meta_key' => '_' . $fieldName,
+            'meta_value' => $internal,
+        ]);
+
+        $override['post_name'] = $internal;
+        $override['post_excerpt'] = $type;
+
+        $acffield = factory(AcfField::class)->create($override);
+        return $acffield;
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -66,9 +66,11 @@ class TestCase extends OrchestraTestCase
     /**
      * Create a acf field for a post with a field name and a value
      */
-    protected function createAcfField(Post $post, $fieldName, $value, $states = [], $override = [])
+    protected function createAcfField(Post $post, $fieldName, $value, $states = [], $override = [], $internal = null)
     {
-        $internal = 'field_' . str_random(13);
+        if (!$internal) {
+            $internal = 'field_' . str_random(13);
+        }
 
         $postmeta1 = factory(PostMeta::class)->create([
             'post_id' => $post->ID,
@@ -90,13 +92,19 @@ class TestCase extends OrchestraTestCase
     /**
      * Create an acf field for use in an option page
      */
-    protected function createOptionAcfField(AcfFieldGroup $fieldGroup, $prefix, $fieldName, $value, $states = [], $override = [])
+    protected function createOptionAcfField(AcfFieldGroup $fieldGroup, $prefix, $fieldName, $value, $states = [], $override = [], $internal = null)
     {
-        $internal = 'field_' . str_random(13);
+        if (!$internal) {
+            $internal = 'field_' . str_random(13);
+        }
 
         factory(Option::class)->create([
             'option_name' => $prefix . $fieldName,
             'option_value' => $value,
+        ]);
+        factory(Option::class)->create([
+            'option_name' => '_' . $prefix . $fieldName,
+            'option_value' => $internal,
         ]);
 
         $override['post_name'] = $internal;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,6 @@
 namespace Corcel\Acf\Tests;
 
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
-use Corcel\Model\Attachment;
 use Corcel\Model\Post;
 use Corcel\Model\Meta\PostMeta;
 use Corcel\Acf\Models\AcfField;
@@ -60,28 +59,6 @@ class TestCase extends OrchestraTestCase
         ]);
 
         $app['config']->set('database.default', 'wp');
-    }
-
-    /**
-     * Create a sample post with acf fields
-     */
-    protected function createAcfPost()
-    {
-        $post = factory(Post::class)->create();
-        $this->createAcfField($post, 'fake_text', 'Proin eget tortor risus');
-        $this->createAcfField($post, 'fake_textarea', 'Praesent sapien massa, convallis a pellentesque nec, egestas non nisi.', 'textarea');
-        $this->createAcfField($post, 'fake_number', '1984', 'number');
-        $this->createAcfField($post, 'fake_email', 'junior@corcel.org', 'email');
-        $this->createAcfField($post, 'fake_url', 'https://corcel.org', 'url');
-        $this->createAcfField($post, 'fake_password', '123change', 'password');
-
-        $this->createAcfField($post, 'fake_select', 'red', 'select');
-        $this->createAcfField($post, 'fake_select_multiple', serialize(['yellow', 'green']), 'select_multiple');
-        $this->createAcfField($post, 'fake_checkbox', serialize(['blue', 'yellow']), 'checkbox');
-        $this->createAcfField($post, 'fake_radio_button', 'green', 'radio_button');
-        $this->createAcfField($post, 'fake_true_false', '1', 'true_false');
-
-        return $post;
     }
 
     /**

--- a/tests/database/factories/AcfFieldFactory.php
+++ b/tests/database/factories/AcfFieldFactory.php
@@ -179,3 +179,15 @@ $factory->state(AcfField::class, 'taxonomy_single', function (Faker\Generator $f
         'post_content' => 'a:13:{s:4:"type";s:8:"taxonomy";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:8:"taxonomy";s:8:"category";s:10:"field_type";s:5:"radio";s:10:"allow_null";i:0;s:8:"add_term";i:1;s:10:"save_terms";i:0;s:10:"load_terms";i:0;s:13:"return_format";s:6:"object";s:8:"multiple";i:0;}',
     ];
 });
+
+$factory->state(AcfField::class, 'repeater', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:10:{s:4:"type";s:8:"repeater";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:9:"collapsed";s:0:"";s:3:"min";s:0:"";s:3:"max";s:0:"";s:6:"layout";s:5:"table";s:12:"button_label";s:7:"Add Row";}',
+    ];
+});
+
+$factory->state(AcfField::class, 'flexible_content', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:9:{s:4:"type";s:16:"flexible_content";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:12:"button_label";s:7:"Add Row";s:3:"min";s:0:"";s:3:"max";s:0:"";s:7:"layouts";a:3:{i:0;a:6:{s:3:"key";s:13:"589c18bcf10da";s:5:"label";s:11:"Normal text";s:4:"name";s:11:"normal_text";s:7:"display";s:5:"block";s:3:"min";s:0:"";s:3:"max";s:0:"";}i:1;a:6:{s:3:"key";s:13:"589c18dfc9b28";s:5:"label";s:12:"Related post";s:4:"name";s:12:"related_post";s:7:"display";s:5:"block";s:3:"min";s:0:"";s:3:"max";s:0:"";}i:2;a:6:{s:3:"key";s:13:"589c1ee35ec27";s:5:"label";s:14:"Multiple posts";s:4:"name";s:14:"multiple_posts";s:7:"display";s:5:"block";s:3:"min";s:0:"";s:3:"max";s:0:"";}}}',
+    ];
+});

--- a/tests/database/factories/AcfFieldFactory.php
+++ b/tests/database/factories/AcfFieldFactory.php
@@ -137,3 +137,15 @@ $factory->state(AcfField::class, 'date_time_picker', function (Faker\Generator $
         'post_content' => 'a:8:{s:4:"type";s:16:"date_time_picker";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:14:"display_format";s:11:"d/m/Y g:i a";s:13:"return_format";s:11:"d/m/Y g:i a";s:9:"first_day";i:1;}',
     ];
 });
+
+$factory->state(AcfField::class, 'time_picker', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:7:{s:4:"type";s:11:"time_picker";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:14:"display_format";s:5:"g:i a";s:13:"return_format";s:5:"g:i a";}',
+    ];
+});
+
+$factory->state(AcfField::class, 'color_picker', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:6:{s:4:"type";s:12:"color_picker";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:13:"default_value";s:7:"#ffcc99";}',
+    ];
+});

--- a/tests/database/factories/AcfFieldFactory.php
+++ b/tests/database/factories/AcfFieldFactory.php
@@ -149,3 +149,33 @@ $factory->state(AcfField::class, 'color_picker', function (Faker\Generator $fake
         'post_content' => 'a:6:{s:4:"type";s:12:"color_picker";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:13:"default_value";s:7:"#ffcc99";}',
     ];
 });
+
+$factory->state(AcfField::class, 'post_object', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:11:{s:4:"type";s:11:"post_object";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:9:"post_type";a:0:{}s:8:"taxonomy";a:0:{}s:10:"allow_null";i:0;s:8:"multiple";i:0;s:13:"return_format";s:6:"object";s:2:"ui";i:1;}',
+    ];
+});
+
+$factory->state(AcfField::class, 'page_link', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:9:{s:4:"type";s:9:"page_link";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:9:"post_type";a:1:{i:0;s:4:"page";}s:8:"taxonomy";a:0:{}s:10:"allow_null";i:0;s:8:"multiple";i:0;}',
+    ];
+});
+
+$factory->state(AcfField::class, 'relationship', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:12:{s:4:"type";s:12:"relationship";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:9:"post_type";a:1:{i:0;s:4:"page";}s:8:"taxonomy";a:0:{}s:7:"filters";a:3:{i:0;s:6:"search";i:1;s:9:"post_type";i:2;s:8:"taxonomy";}s:8:"elements";s:0:"";s:3:"min";s:0:"";s:3:"max";s:0:"";s:13:"return_format";s:6:"object";}',
+    ];
+});
+
+$factory->state(AcfField::class, 'taxonomy', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:13:{s:4:"type";s:8:"taxonomy";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:8:"taxonomy";s:8:"category";s:10:"field_type";s:8:"checkbox";s:10:"allow_null";i:0;s:8:"add_term";i:1;s:10:"save_terms";i:0;s:10:"load_terms";i:0;s:13:"return_format";s:2:"id";s:8:"multiple";i:0;}',
+    ];
+});
+
+$factory->state(AcfField::class, 'taxonomy_single', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:13:{s:4:"type";s:8:"taxonomy";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:8:"taxonomy";s:8:"category";s:10:"field_type";s:5:"radio";s:10:"allow_null";i:0;s:8:"add_term";i:1;s:10:"save_terms";i:0;s:10:"load_terms";i:0;s:13:"return_format";s:6:"object";s:8:"multiple";i:0;}',
+    ];
+});

--- a/tests/database/factories/AcfFieldFactory.php
+++ b/tests/database/factories/AcfFieldFactory.php
@@ -3,16 +3,14 @@
 use Illuminate\Support\Str;
 use Corcel\Acf\Models\AcfField;
 
-$factory->define(AcfField::class, function (Faker\Generator $faker, $options) {
-    $type = (empty($options['post_excerpt']) ? 'text' : $options['post_excerpt']);
-
+$factory->define(AcfField::class, function (Faker\Generator $faker) {
     return [
         'post_author' => $faker->name,
         'post_date' => $faker->dateTimeThisYear,
         'post_date_gmt' => $faker->dateTimeThisYear,
-        'post_content' => serialize(['type' => $type]),
+        'post_content' => 'a:12:{s:4:"type";s:4:"text";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:13:"default_value";s:0:"";s:11:"placeholder";s:0:"";s:7:"prepend";s:0:"";s:6:"append";s:0:"";s:9:"maxlength";s:0:"";s:8:"readonly";i:0;s:8:"disabled";i:0;}',
         'post_title' => $faker->title,
-        'post_excerpt' => $type,
+        'post_excerpt' => $faker->word,
         'post_status' => 'publish',
         'comment_status' => 'closed',
         'ping_status' => 'closed',
@@ -31,3 +29,64 @@ $factory->define(AcfField::class, function (Faker\Generator $faker, $options) {
         'comment_count' => 0,
     ];
 });
+
+$factory->state(AcfField::class, 'textarea', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:12:{s:4:"type";s:8:"textarea";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:13:"default_value";s:0:"";s:11:"placeholder";s:0:"";s:9:"maxlength";s:0:"";s:4:"rows";s:0:"";s:9:"new_lines";s:7:"wpautop";s:8:"readonly";i:0;s:8:"disabled";i:0;}',
+    ];
+});
+
+$factory->state(AcfField::class, 'number', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:14:{s:4:"type";s:6:"number";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:13:"default_value";s:0:"";s:11:"placeholder";s:0:"";s:7:"prepend";s:0:"";s:6:"append";s:0:"";s:3:"min";s:0:"";s:3:"max";s:0:"";s:4:"step";s:0:"";s:8:"readonly";i:0;s:8:"disabled";i:0;}',
+    ];
+});
+
+$factory->state(AcfField::class, 'email', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:9:{s:4:"type";s:5:"email";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:13:"default_value";s:0:"";s:11:"placeholder";s:0:"";s:7:"prepend";s:0:"";s:6:"append";s:0:"";}',
+    ];
+});
+
+$factory->state(AcfField::class, 'url', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:7:{s:4:"type";s:3:"url";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:13:"default_value";s:0:"";s:11:"placeholder";s:0:"";}',
+    ];
+});
+
+$factory->state(AcfField::class, 'password', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:12:{s:4:"type";s:4:"text";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:13:"default_value";s:0:"";s:11:"placeholder";s:0:"";s:7:"prepend";s:0:"";s:6:"append";s:0:"";s:9:"maxlength";s:0:"";s:8:"readonly";i:0;s:8:"disabled";i:0;}',
+    ];
+});
+
+$factory->state(AcfField::class, 'select', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:14:{s:4:"type";s:6:"select";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:7:"choices";a:4:{s:3:"red";s:3:"Red";s:4:"blue";s:4:"Blue";s:6:"yellow";s:6:"Yellow";s:5:"green";s:5:"Green";}s:13:"default_value";a:0:{}s:10:"allow_null";i:0;s:8:"multiple";i:1;s:2:"ui";i:0;s:4:"ajax";i:0;s:11:"placeholder";s:0:"";s:8:"disabled";i:0;s:8:"readonly";i:0;}',
+    ];
+});
+
+$factory->state(AcfField::class, 'select_multiple', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:14:{s:4:"type";s:6:"select";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:7:"choices";a:4:{s:3:"red";s:3:"Red";s:4:"blue";s:4:"Blue";s:6:"yellow";s:6:"Yellow";s:5:"green";s:5:"Green";}s:13:"default_value";a:0:{}s:10:"allow_null";i:0;s:8:"multiple";i:1;s:2:"ui";i:0;s:4:"ajax";i:0;s:11:"placeholder";s:0:"";s:8:"disabled";i:0;s:8:"readonly";i:0;}',
+    ];
+});
+
+$factory->state(AcfField::class, 'checkbox', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:9:{s:4:"type";s:8:"checkbox";s:12:"instructions";s:0:"";s:8:"required";i:1;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:7:"choices";a:4:{s:3:"red";s:3:"Red";s:4:"blue";s:4:"Blue";s:6:"yellow";s:6:"Yellow";s:5:"green";s:5:"Green";}s:13:"default_value";a:0:{}s:6:"layout";s:8:"vertical";s:6:"toggle";i:0;}',
+    ];
+});
+
+$factory->state(AcfField::class, 'radio_button', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:11:{s:4:"type";s:5:"radio";s:12:"instructions";s:0:"";s:8:"required";i:1;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:7:"choices";a:4:{s:3:"red";s:3:"Red";s:4:"blue";s:4:"Blue";s:6:"yellow";s:6:"Yellow";s:5:"green";s:5:"Green";}s:10:"allow_null";i:0;s:12:"other_choice";i:0;s:17:"save_other_choice";i:0;s:13:"default_value";s:0:"";s:6:"layout";s:8:"vertical";}',
+    ];
+});
+
+$factory->state(AcfField::class, 'true_false', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:7:{s:4:"type";s:10:"true_false";s:12:"instructions";s:0:"";s:8:"required";s:0:"";s:17:"conditional_logic";s:0:"";s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:7:"message";s:0:"";s:13:"default_value";i:0;}',
+    ];
+});
+

--- a/tests/database/factories/AcfFieldFactory.php
+++ b/tests/database/factories/AcfFieldFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Str;
+use Corcel\Acf\Models\AcfField;
+
+$factory->define(AcfField::class, function (Faker\Generator $faker, $options) {
+    $type = (empty($options['post_excerpt']) ? 'text' : $options['post_excerpt']);
+
+    return [
+        'post_author' => $faker->name,
+        'post_date' => $faker->dateTimeThisYear,
+        'post_date_gmt' => $faker->dateTimeThisYear,
+        'post_content' => serialize(['type' => $type]),
+        'post_title' => $faker->title,
+        'post_excerpt' => $type,
+        'post_status' => 'publish',
+        'comment_status' => 'closed',
+        'ping_status' => 'closed',
+        'post_password' => '',
+        'post_name' => 'field_' . Str::random(13),
+        'to_ping' => '',
+        'pinged' => '',
+        'post_modified' => $faker->dateTimeThisMonth,
+        'post_modified_gmt' => $faker->dateTimeThisMonth,
+        'post_content_filtered' => '',
+        'post_parent' => 0,
+        'guid' => 'http://example.com/?p=' . $faker->numberBetween(1, 100),
+        'menu_order' => 0,
+        'post_type' => 'acf-field',
+        'post_mime_type' => '',
+        'comment_count' => 0,
+    ];
+});

--- a/tests/database/factories/AcfFieldFactory.php
+++ b/tests/database/factories/AcfFieldFactory.php
@@ -90,3 +90,32 @@ $factory->state(AcfField::class, 'true_false', function (Faker\Generator $faker)
     ];
 });
 
+$factory->state(AcfField::class, 'editor', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:9:{s:4:"type";s:7:"wysiwyg";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:13:"default_value";s:0:"";s:4:"tabs";s:3:"all";s:7:"toolbar";s:4:"full";s:12:"media_upload";i:1;}',
+    ];
+});
+
+$factory->state(AcfField::class, 'oembed', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:7:{s:4:"type";s:6:"oembed";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:5:"width";i:640;s:6:"height";i:390;}',
+    ];
+});
+
+$factory->state(AcfField::class, 'image', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:15:{s:4:"type";s:5:"image";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:13:"return_format";s:5:"array";s:12:"preview_size";s:9:"thumbnail";s:7:"library";s:3:"all";s:9:"min_width";s:0:"";s:10:"min_height";s:0:"";s:8:"min_size";s:0:"";s:9:"max_width";s:0:"";s:10:"max_height";s:0:"";s:8:"max_size";s:0:"";s:10:"mime_types";s:0:"";}',
+    ];
+});
+
+$factory->state(AcfField::class, 'file', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:10:{s:4:"type";s:4:"file";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:13:"return_format";s:5:"array";s:7:"library";s:3:"all";s:8:"min_size";s:0:"";s:8:"max_size";s:0:"";s:10:"mime_types";s:0:"";}',
+    ];
+});
+
+$factory->state(AcfField::class, 'gallery', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:17:{s:4:"type";s:7:"gallery";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:3:"min";s:0:"";s:3:"max";s:0:"";s:12:"preview_size";s:9:"thumbnail";s:6:"insert";s:6:"append";s:7:"library";s:3:"all";s:9:"min_width";s:0:"";s:10:"min_height";s:0:"";s:8:"min_size";s:0:"";s:9:"max_width";s:0:"";s:10:"max_height";s:0:"";s:8:"max_size";s:0:"";s:10:"mime_types";s:0:"";}',
+    ];
+});

--- a/tests/database/factories/AcfFieldFactory.php
+++ b/tests/database/factories/AcfFieldFactory.php
@@ -119,3 +119,21 @@ $factory->state(AcfField::class, 'gallery', function (Faker\Generator $faker) {
         'post_content' => 'a:17:{s:4:"type";s:7:"gallery";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:3:"min";s:0:"";s:3:"max";s:0:"";s:12:"preview_size";s:9:"thumbnail";s:6:"insert";s:6:"append";s:7:"library";s:3:"all";s:9:"min_width";s:0:"";s:10:"min_height";s:0:"";s:8:"min_size";s:0:"";s:9:"max_width";s:0:"";s:10:"max_height";s:0:"";s:8:"max_size";s:0:"";s:10:"mime_types";s:0:"";}',
     ];
 });
+
+$factory->state(AcfField::class, 'user', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:8:{s:4:"type";s:4:"user";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:4:"role";s:0:"";s:10:"allow_null";i:0;s:8:"multiple";i:0;}',
+    ];
+});
+
+$factory->state(AcfField::class, 'date_picker', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:8:{s:4:"type";s:11:"date_picker";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:14:"display_format";s:5:"d/m/Y";s:13:"return_format";s:5:"d/m/Y";s:9:"first_day";i:1;}',
+    ];
+});
+
+$factory->state(AcfField::class, 'date_time_picker', function (Faker\Generator $faker) {
+    return [
+        'post_content' => 'a:8:{s:4:"type";s:16:"date_time_picker";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:14:"display_format";s:11:"d/m/Y g:i a";s:13:"return_format";s:11:"d/m/Y g:i a";s:9:"first_day";i:1;}',
+    ];
+});

--- a/tests/database/factories/AcfFieldGroupFactory.php
+++ b/tests/database/factories/AcfFieldGroupFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Str;
+use Corcel\Acf\Models\AcfFieldGroup;
+use Corcel\Model\User;
+
+$factory->define(AcfFieldGroup::class, function (Faker\Generator $faker) {
+    return [
+        'post_author' => factory(User::class)->create()->ID,
+        'post_date' => $faker->dateTimeThisYear,
+        'post_date_gmt' => $faker->dateTimeThisYear,
+        'post_content' => 'a:7:{s:8:"location";a:1:{i:0;a:1:{i:0;a:3:{s:5:"param";s:12:"options_page";s:8:"operator";s:2:"==";s:5:"value";s:29:"acf-options-seiten-optionen22";}}}s:8:"position";s:6:"normal";s:5:"style";s:7:"default";s:15:"label_placement";s:3:"top";s:21:"instruction_placement";s:5:"label";s:14:"hide_on_screen";s:0:"";s:11:"description";s:0:"";}',
+        'post_title' => $title = $faker->title,
+        'post_excerpt' => strtolower($title),
+        'post_status' => 'publish',
+        'comment_status' => 'closed',
+        'ping_status' => 'closed',
+        'post_password' => '',
+        'post_name' => 'group_' . Str::random(13),
+        'to_ping' => '',
+        'pinged' => '',
+        'post_modified' => $faker->dateTimeThisMonth,
+        'post_modified_gmt' => $faker->dateTimeThisMonth,
+        'post_content_filtered' => '',
+        'post_parent' => 0,
+        'guid' => 'http://example.com/?post_type=acf-field-group&#038;p=' . $faker->numberBetween(1, 100),
+        'menu_order' => 0,
+        'post_type' => 'acf-field-group',
+        'post_mime_type' => '',
+        'comment_count' => 0,
+    ];
+});

--- a/tests/database/factories/AttachmentFactory.php
+++ b/tests/database/factories/AttachmentFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+use Corcel\Model\Attachment;
+use Illuminate\Support\Str;
+
+$factory->define(Attachment::class, function (Faker\Generator $faker) {
+    return [
+        'post_author' => $faker->name,
+        'post_date' => $faker->dateTimeThisYear,
+        'post_date_gmt' => $faker->dateTimeThisYear,
+        'post_content' => $faker->text(),
+        'post_title' => $title = $faker->title,
+        'post_excerpt' => $faker->text(100),
+        'post_status' => 'publish',
+        'comment_status' => 'closed',
+        'ping_status' => 'closed',
+        'post_password' => '',
+        'post_name' => Str::slug($title),
+        'to_ping' => '',
+        'pinged' => '',
+        'post_modified' => $faker->dateTimeThisMonth,
+        'post_modified_gmt' => $faker->dateTimeThisMonth,
+        'post_content_filtered' => '',
+        'post_parent' => 0,
+        'guid' => 'http://example.com/?p=' . $faker->numberBetween(1, 100),
+        'menu_order' => 0,
+        'post_type' => 'attachment',
+        'post_mime_type' => 'image/jpeg',
+        'comment_count' => 0,
+    ];
+});
+
+$factory->state(Attachment::class, 'file', function (Faker\Generator $faker) {
+    return [
+        'post_mime_type' => 'application/pdf',
+    ];
+});

--- a/tests/database/factories/PostFactory.php
+++ b/tests/database/factories/PostFactory.php
@@ -1,0 +1,9 @@
+<?php
+
+use Corcel\Model\Post;
+
+$factory->state(Post::class, 'page', function (Faker\Generator $faker) {
+    return [
+        'post_type' => 'page',
+    ];
+});

--- a/tests/database/factories/PostMetaFactory.php
+++ b/tests/database/factories/PostMetaFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+use Corcel\Model\Meta\PostMeta;
+
+$factory->define(PostMeta::class, function (Faker\Generator $faker) {
+    return [
+        'post_id' => $faker->numberBetween(1, 100),
+        'meta_key' => $faker->word,
+        'meta_value' => $faker->sentence(),
+    ];
+});
+
+$factory->state(PostMeta::class, 'attachment_metadata', function(Faker\Generator $faker){
+    return [
+        'meta_key' => '_wp_attachment_metadata',
+        'meta_value' => serialize([
+            'width' => 567,
+            'height' => 345,
+            'file' => '2014/01/test.jpg',
+            'sizes' => [
+                'thumbnail' => [
+                    'file' => 'test-150x150.jpg',
+                    'width' => 150,
+                    'height' => 150,
+                    'mime-type' => 'image/jpeg',
+                ],
+                'medium' => [
+                    'file' => 'test-300x183.jpg',
+                    'width' => 300,
+                    'height' => 183,
+                    'mime-type' => 'image/jpeg',
+                ],
+            ],
+        ]),
+    ];
+
+});

--- a/tests/database/factories/PostMetaFactory.php
+++ b/tests/database/factories/PostMetaFactory.php
@@ -10,7 +10,7 @@ $factory->define(PostMeta::class, function (Faker\Generator $faker) {
     ];
 });
 
-$factory->state(PostMeta::class, 'attachment_metadata', function (Faker\Generator $faker){
+$factory->state(PostMeta::class, 'attachment_metadata', function (Faker\Generator $faker) {
     return [
         'meta_key' => '_wp_attachment_metadata',
         'meta_value' => serialize([

--- a/tests/database/factories/PostMetaFactory.php
+++ b/tests/database/factories/PostMetaFactory.php
@@ -13,24 +13,6 @@ $factory->define(PostMeta::class, function (Faker\Generator $faker) {
 $factory->state(PostMeta::class, 'attachment_metadata', function (Faker\Generator $faker) {
     return [
         'meta_key' => '_wp_attachment_metadata',
-        'meta_value' => serialize([
-            'width' => 567,
-            'height' => 345,
-            'file' => '2014/01/test.jpg',
-            'sizes' => [
-                'thumbnail' => [
-                    'file' => 'test-150x150.jpg',
-                    'width' => 150,
-                    'height' => 150,
-                    'mime-type' => 'image/jpeg',
-                ],
-                'medium' => [
-                    'file' => 'test-300x183.jpg',
-                    'width' => 300,
-                    'height' => 183,
-                    'mime-type' => 'image/jpeg',
-                ],
-            ],
-        ]),
+        'meta_value' => 'a:5:{s:5:"width";i:1920;s:6:"height";i:1080;s:4:"file";s:27:"2016/10/maxresdefault-1.jpg";s:5:"sizes";a:5:{s:9:"thumbnail";a:4:{s:4:"file";s:27:"maxresdefault-1-150x150.jpg";s:5:"width";i:150;s:6:"height";i:150;s:9:"mime-type";s:10:"image/jpeg";}s:6:"medium";a:4:{s:4:"file";s:27:"maxresdefault-1-300x169.jpg";s:5:"width";i:300;s:6:"height";i:169;s:9:"mime-type";s:10:"image/jpeg";}s:12:"medium_large";a:4:{s:4:"file";s:27:"maxresdefault-1-768x432.jpg";s:5:"width";i:768;s:6:"height";i:432;s:9:"mime-type";s:10:"image/jpeg";}s:5:"large";a:4:{s:4:"file";s:28:"maxresdefault-1-1024x576.jpg";s:5:"width";i:1024;s:6:"height";i:576;s:9:"mime-type";s:10:"image/jpeg";}s:14:"post-thumbnail";a:4:{s:4:"file";s:28:"maxresdefault-1-1200x675.jpg";s:5:"width";i:1200;s:6:"height";i:675;s:9:"mime-type";s:10:"image/jpeg";}}s:10:"image_meta";a:12:{s:8:"aperture";s:1:"0";s:6:"credit";s:0:"";s:6:"camera";s:0:"";s:7:"caption";s:0:"";s:17:"created_timestamp";s:1:"0";s:9:"copyright";s:0:"";s:12:"focal_length";s:1:"0";s:3:"iso";s:1:"0";s:13:"shutter_speed";s:1:"0";s:5:"title";s:0:"";s:11:"orientation";s:1:"0";s:8:"keywords";a:0:{}}}',
     ];
 });

--- a/tests/database/factories/PostMetaFactory.php
+++ b/tests/database/factories/PostMetaFactory.php
@@ -10,7 +10,7 @@ $factory->define(PostMeta::class, function (Faker\Generator $faker) {
     ];
 });
 
-$factory->state(PostMeta::class, 'attachment_metadata', function(Faker\Generator $faker){
+$factory->state(PostMeta::class, 'attachment_metadata', function (Faker\Generator $faker){
     return [
         'meta_key' => '_wp_attachment_metadata',
         'meta_value' => serialize([
@@ -33,5 +33,4 @@ $factory->state(PostMeta::class, 'attachment_metadata', function(Faker\Generator
             ],
         ]),
     ];
-
 });


### PR DESCRIPTION
Hey,

as mentioned in #48 this is the big PR to implement the acf option page. I basically moved a lot of code from the single Field classes to a new layer called "Repository". All the "old" code sits now in the PostRepository (which holds the $post instance). The single fields get the repository now in the constructor and all database access runs through that repository.
For the option page, we have a second OptionPageRepository which returns the according data to the fields from wp_options.
So we can have the same logic for fields from posts/pages and from a option page.
Additionally, as FieldFactory::make() takes a repository now as parameter, users can write their own repositories and everything is a lot more decoupled and flexible.

The second big change covers the unit tests: i have seen that their was only a database.sql in the repo, and the unit tests run only on a real database. I have changed all unit tests to run with mocked models & factories as in the corcel package. Basically i have copied the values from the testing database into the code, so the tests did not need to change a lot.
I have updated the underlying corcel version to 2.4 (for laravel 5.4 since 5.5 needs php>=7) and have added the orchestra test package as well.

Yeah, i hope you can take some time to review this, though i have made sure that everything is backwards-compatible