### PR TITLE
Bugfix for Image fields when using a non-default connection

### DIFF
--- a/src/Field/Image.php
+++ b/src/Field/Image.php
@@ -3,7 +3,6 @@
 namespace Corcel\Acf\Field;
 
 use Corcel\Model\Post;
-use Corcel\Model\Meta\PostMeta;
 use Corcel\Acf\FieldInterface;
 use Illuminate\Database\Eloquent\Collection;
 
@@ -133,9 +132,10 @@ class Image extends BasicField implements FieldInterface
      */
     protected function fetchMetadataValue(Post $attachment)
     {
-        $meta = PostMeta::where('post_id', $attachment->ID)
-                        ->where('meta_key', '_wp_attachment_metadata')
-                        ->first();
+        $meta = $this->postMeta
+            ->where('post_id', $attachment->ID)
+            ->where('meta_key', '_wp_attachment_metadata')
+            ->first();
 
         return unserialize($meta->meta_value);
     }
@@ -150,10 +150,11 @@ class Image extends BasicField implements FieldInterface
         $ids = $attachments->pluck('ID')->toArray();
         $metadataValues = [];
 
-        $metaRows = PostMeta::whereIn("post_id", $ids)
+        $metaRows = $this->postMeta
+            ->whereIn("post_id", $ids)
             ->where('meta_key', '_wp_attachment_metadata')
             ->get();
-            
+
         foreach ($metaRows as $meta) {
             $metadataValues[$meta->post_id] = unserialize($meta->meta_value);
         }

--- a/tests/CorcelIntegrationTest.php
+++ b/tests/CorcelIntegrationTest.php
@@ -1,6 +1,17 @@
 <?php
 
 use Corcel\Model\Post;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+
+class AlternatePost extends Post
+{
+    /**
+     * The connection name for the model.
+     *
+     * @var string
+     */
+    protected $connection = 'alternate';
+}
 
 /**
  * Class CorcelIntegrationTest.
@@ -9,6 +20,13 @@ use Corcel\Model\Post;
  */
 class CorcelIntegrationTest extends PHPUnit_Framework_TestCase
 {
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        Eloquent::getConnectionResolver()->setDefaultConnection('default');
+    }
+
     public function testIfCorcelIntegrationIsWorking()
     {
         $post = Post::find(56);
@@ -26,5 +44,13 @@ class CorcelIntegrationTest extends PHPUnit_Framework_TestCase
         $post = Post::find(65);
         $this->assertEquals('10/13/2016', $post->acf->fake_date_picker->format('m/d/Y'));
         $this->assertEquals('10/13/2016', $post->acf->datePicker('fake_date_picker')->format('m/d/Y'));
+    }
+
+    public function testPostWithNonDefaultConnectionsLoadsFieldsUsingSameConnection()
+    {
+        Eloquent::getConnectionResolver()->setDefaultConnection('missing');
+
+        $post = AlternatePost::find(38);
+        $this->assertEquals('http://wordpress.corcel.dev/wp-content/uploads/2016/10/maxresdefault-1.jpg', $post->acf->image('fake_image')->url);
     }
 }

--- a/tests/config/bootstrap.php
+++ b/tests/config/bootstrap.php
@@ -11,3 +11,7 @@ $capsule = \Corcel\Database::connect($params = [
     'password' => '',
     'host' => '127.0.0.1',
 ]);
+
+// Create a copy of the default connection called alternate:
+$config = $capsule->getContainer()->make('config')->get('database.connections')['default'];
+$capsule->addConnection($config, 'alternate');


### PR DESCRIPTION
Image fields only used the default connection when loading rather than using parent Post's connection. I noticed that for all fields there is a `postMeta` that is set to use the same connection as the parent, so the Image field has been changed to use this instead of using the base `PostMeta` macro methods.

In order to test this I've had to create a new connection in `tests/config/bootstrap.php`, and also make a fixture class in `tests/CorcelIntegrationTest.php`. I would have put it in its own file, but the tests themselves aren't loaded via PSR-4. I thought it would be simpler to add the class inline for the time being, as its a wider change to load them all this way.