### PR TITLE
Make image sizes accessible

### DIFF
--- a/src/Field/Image.php
+++ b/src/Field/Image.php
@@ -47,7 +47,7 @@ class Image extends BasicField implements FieldInterface
     /**
      * @var array
      */
-    protected $sizes = [];
+    public $sizes = [];
 
     /**
      * @var bool


### PR DESCRIPTION
So that all image sizes are readily available if you need to iterate over them (for responsive images, for instance).